### PR TITLE
사이드바 메뉴 스타일·기능 구현 및 PrivateLayout/PrivateHeader 구조 구성

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -25,6 +25,6 @@
 
 /* 모든 요소의 기본 여백 제거 → 브라우저별 기본 margin/padding 차이를 제거하여 레이아웃을 예측 가능하게 만듦 */
 * {
-  padding: 0;
-  margin: 0;
+  /* padding: 0; */
+  /* margin: 0; */
 }

--- a/src/shared/Layout/PrivateHeader.tsx
+++ b/src/shared/Layout/PrivateHeader.tsx
@@ -1,8 +1,21 @@
+import { MenuList } from "./sidebar/MenuList";
+
 function PrivateSidebar() {
   return (
-    <div className="min-w-40 bg-primary-light">
-      <p>에스드럼기타</p>
+    <div className="min-w-50 bg-primary-light flex flex-col">
+      <LogoName />
+      <MenuList />
     </div>
   );
 }
 export default PrivateSidebar;
+
+const LogoName = () => {
+  return (
+    <p className="text-2xl font-bold px-4 py-10">
+      에스드럼기타
+      <br />
+      음악교습소
+    </p>
+  );
+};

--- a/src/shared/Layout/PrivateLayout.tsx
+++ b/src/shared/Layout/PrivateLayout.tsx
@@ -3,7 +3,7 @@ import PrivateSidebar from "./PrivateHeader";
 
 function PrivateLayout() {
   return (
-    <div className="w-full flex">
+    <div className="w-full flex min-h-screen">
       <PrivateSidebar />
       <Outlet />
     </div>

--- a/src/shared/Layout/sidebar/MenuList.tsx
+++ b/src/shared/Layout/sidebar/MenuList.tsx
@@ -1,0 +1,23 @@
+import { NavLink } from "react-router-dom";
+import { MENU_LIST } from "./menu.constants";
+
+export const MenuList = () => {
+  const baseClass = "px-4 py-2 text-base transition-all duration-300";
+  const activeClass = "bg-primary text-white font-bold text-lg";
+
+  return (
+    <nav className="flex flex-col">
+      {MENU_LIST.map((menu) => (
+        <NavLink
+          key={menu.href}
+          to={menu.href}
+          className={({ isActive }) =>
+            `${baseClass} ${isActive ? activeClass : ""}`
+          }
+        >
+          {menu.label}
+        </NavLink>
+      ))}
+    </nav>
+  );
+};

--- a/src/shared/Layout/sidebar/menu.constants.ts
+++ b/src/shared/Layout/sidebar/menu.constants.ts
@@ -1,0 +1,9 @@
+import type { MenuItem } from "./types";
+
+export const MENU_LIST: MenuItem[] = [
+  { href: "/home", label: "홈" },
+  { href: "/student", label: "학생" },
+  { href: "/course", label: "수강" },
+  { href: "/schedule", label: "일정" },
+  { href: "/message", label: "메시지" },
+];

--- a/src/shared/Layout/sidebar/types.ts
+++ b/src/shared/Layout/sidebar/types.ts
@@ -1,0 +1,5 @@
+export interface MenuItem {
+  href: string;
+  label: string;
+  icon?: React.ReactNode;
+}

--- a/src/theme.css
+++ b/src/theme.css
@@ -8,4 +8,8 @@
   .bg-primary-light {
     @apply bg-[#D5DEF5];
   }
+
+  .bg-primary {
+    @apply bg-[#6181D8];
+  }
 }


### PR DESCRIPTION
사이드바메뉴에 대한 스타일 및 기능을 구현했습니다.

- PrivateLayout : 로그인 후 사용되는 페이지의 기본 레이아웃
- PrivateHeader : PrivateLayout의 공용 사이드바메뉴
- sidebar 폴더 : MenuList를 위한 컴포넌트 및 타입, 상수 파일 폴더
- theme.css : 필요한 색상 유틸리티 정의