### PR TITLE
폼/선택 UI 개선 및 홈·학생·과정·스케줄 캐시/새로고침 흐름 강화, 레슨 타입 정합성 수정

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,25 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import './index.css';
 import './theme.css';
 import Router from '@/utils/router';
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5,
+      gcTime: 1000 * 60 * 30,
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  },
+});
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <Router />
+    <QueryClientProvider client={queryClient}>
+      <Router />
+    </QueryClientProvider>
   </StrictMode>,
 );

--- a/src/pages/course/index.tsx
+++ b/src/pages/course/index.tsx
@@ -11,7 +11,7 @@ import { getClassTypeLabel } from '@/utils/course/getClassTypeLabel';
 import { getCourses } from '@/shared/api/courses';
 import Chip from '@/shared/chip/Chip';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import type { GetCoursesResponse } from '@/shared/api/courses';
+import type { GetCoursesResponse } from '@/shared/api/courses/courses.types';
 
 const formatToHourMinute = (time?: string) => {
   if (!time) return '';

--- a/src/pages/course/index.tsx
+++ b/src/pages/course/index.tsx
@@ -3,7 +3,6 @@ import { useCourseModalStore } from '@/store/course/courseModalStore';
 
 import TableSection from '../../shared/modal/TableSection';
 import type { Course } from '@/types/course';
-import { useEffect, useState } from 'react';
 
 import CourseModal from './modal/CourseModal';
 import { getWeekdayLabel } from '@/utils/date/getWeekdayLabel';
@@ -11,6 +10,8 @@ import { formatToKoreanDate } from '@/utils/date/formatKoreanDate';
 import { getClassTypeLabel } from '@/utils/course/getClassTypeLabel';
 import { getCourses } from '@/shared/api/courses';
 import Chip from '@/shared/chip/Chip';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import type { GetCoursesResponse } from '@/shared/api/courses';
 
 const formatToHourMinute = (time?: string) => {
   if (!time) return '';
@@ -34,20 +35,71 @@ const getInvoiceChipProps = (status: Course['invoice']['status']) =>
 
 function CoursePage() {
   const { isOpen, openCreate, openDetail } = useCourseModalStore();
-  const [courses, setCourses] = useState<Course[]>([]);
+  const queryClient = useQueryClient();
+  const homeCache = queryClient.getQueryData<GetCoursesResponse>([
+    'home',
+    'courses',
+    1,
+    3,
+  ]);
+  const homeCacheUpdatedAt = queryClient.getQueryState([
+    'home',
+    'courses',
+    1,
+    3,
+  ])?.dataUpdatedAt;
 
-  const loadCourse = async () => {
-    const { courses } = await getCourses({ page: 1, size: 20 });
-    setCourses(courses);
-  };
+  const { data, isFetching, refetch } = useQuery({
+    queryKey: ['courses', { page: 1, size: 20 }],
+    queryFn: () => getCourses({ page: 1, size: 20 }),
+    initialData: homeCache
+      ? { ...homeCache, page: 1, size: 20 }
+      : undefined,
+    initialDataUpdatedAt: homeCache ? homeCacheUpdatedAt : undefined,
+    staleTime: 1000 * 60 * 5,
+    refetchOnMount: (query) => query.isStale(),
+  });
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    loadCourse();
-  }, []);
+  const courses = data?.courses ?? [];
   return (
     <div>
-      <ModalOpenButton text="신규수업 추가" openModal={openCreate} />
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <ModalOpenButton text="신규수업 추가" openModal={openCreate} />
+        <button
+          type="button"
+          onClick={() => refetch()}
+          disabled={isFetching}
+          className={`inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 ${
+            isFetching
+              ? 'border-gray-200 text-gray-400 cursor-not-allowed'
+              : 'border-primary text-primary hover:bg-primary/10 active:scale-95 active:bg-primary/20'
+          }`}
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 20 20"
+            fill="none"
+            aria-hidden="true"
+            className={isFetching ? 'animate-spin' : ''}
+          >
+            <path
+              d="M16 10a6 6 0 1 1-1.76-4.24"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+            />
+            <path
+              d="M16 4v4h-4"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          최신화
+        </button>
+      </div>
       <TableSection<Course>
         dataList={courses}
         headers={[
@@ -87,7 +139,7 @@ function CoursePage() {
         }}
         onRowClick={(course) => openDetail(course)}
       />
-      {isOpen && <CourseModal onSuccess={loadCourse} />}
+      {isOpen && <CourseModal onSuccess={refetch} />}
     </div>
   );
 }

--- a/src/pages/course/modal/CourseForm.tsx
+++ b/src/pages/course/modal/CourseForm.tsx
@@ -26,6 +26,7 @@ import {
   PAYMENT_STATUS_OPTIONS,
 } from '@/constants/invoice';
 import { useToastStore } from '@/store/feedback/toastStore';
+import ConfirmModal from '@/shared/modal/ConfirmModal';
 
 interface CourseFormState {
   student: {
@@ -96,6 +97,7 @@ export default function CourseForm({
   const [form, setForm] = useState<CourseFormState>(initialState);
   const [initialForm] = useState<CourseFormState>(initialState);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isCancelConfirmOpen, setIsCancelConfirmOpen] = useState(false);
 
   const updateForm = <K extends keyof CourseFormState>(
     key: K,
@@ -108,6 +110,9 @@ export default function CourseForm({
   };
 
   const { isOpen, open } = useDateModalStore();
+  const [activeDateField, setActiveDateField] = useState<
+    'start' | 'paid' | null
+  >(null);
 
   const isViewMode = mode === 'DETAIL';
   const isDirty = JSON.stringify(form) !== JSON.stringify(initialForm);
@@ -115,6 +120,17 @@ export default function CourseForm({
   useEffect(() => {
     onDirtyChange(isDirty);
   }, [isDirty, onDirtyChange]);
+
+  const handleCancelEdit = () => {
+    setForm(initialForm);
+    setMode('DETAIL');
+  };
+
+  useEffect(() => {
+    if (!isOpen) {
+      setActiveDateField(null);
+    }
+  }, [isOpen]);
 
   const isBaseInfoValid =
     form.student.name.trim() !== '' &&
@@ -211,7 +227,7 @@ export default function CourseForm({
             const { student: detail } = await getStudent(student.id);
             updateForm('family_discount', Boolean(detail?.family_discount));
           }}
-          disabled={isViewMode}
+          disabled={isViewMode || mode === 'UPDATE'}
         />
       </FormField>
       <FormField label="클래스">
@@ -234,29 +250,29 @@ export default function CourseForm({
 
       <FormField label="수강 시작 날짜">
         <div
-          className={`border rounded-sm py-1 px-2 flex justify-between
+          className={`border rounded-sm py-1 px-2 flex justify-between items-center
         ${
           isViewMode
             ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
             : 'border-primary text-primary'
         }`}
         >
-          <p>
+          <p className="text-sm">
             {form.start_date
               ? formatToKoreanDate(form.start_date)
               : '날짜를 선택해주세요.'}
           </p>
           <button
-            onClick={open}
+            onClick={() => {
+              setActiveDateField('start');
+              open();
+            }}
             disabled={isViewMode}
-            className={`${isViewMode && 'cursor-none'}`}
+            className={`text-sm ${isViewMode && 'cursor-none'}`}
           >
             선택
           </button>
         </div>
-        {isOpen && (
-          <CalendarModal onSelect={(date) => updateForm('start_date', date)} />
-        )}
       </FormField>
 
       <FormField label="수강 요일">
@@ -318,33 +334,88 @@ export default function CourseForm({
           </FormField>
 
           <FormField label="결제일">
-            <TextInput
-              type="date"
-              value={form.invoice.paid_at}
-              onChange={(v) =>
-                updateForm('invoice', {
-                  ...form.invoice,
-                  paid_at: v,
-                })
-              }
-              disabled={isViewMode}
-            />
+            <div
+              className={`border rounded-sm py-1 px-2 flex justify-between
+            ${
+              isViewMode
+                ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
+                : 'border-primary text-primary'
+            }`}
+            >
+              <p className="text-sm">
+                {form.invoice.paid_at
+                  ? formatToKoreanDate(form.invoice.paid_at)
+                  : '날짜를 선택해주세요.'}
+              </p>
+              <button
+                onClick={() => {
+                  setActiveDateField('paid');
+                  open();
+                }}
+                disabled={isViewMode}
+                className={`text-sm ${isViewMode && 'cursor-none'}`}
+              >
+                선택
+              </button>
+            </div>
           </FormField>
         </>
+      )}
+
+      {isOpen && (
+        <CalendarModal
+          onSelect={(date) => {
+            if (activeDateField === 'start') {
+              updateForm('start_date', date);
+            }
+            if (activeDateField === 'paid') {
+              updateForm('invoice', {
+                ...form.invoice,
+                paid_at: date,
+              });
+            }
+          }}
+        />
       )}
 
       <div className="w-full flex justify-end gap-2">
         {mode === 'DETAIL' ? (
           <NormalButton onClick={() => setMode('UPDATE')} text="수정" />
         ) : (
-          <NormalButton
-            onClick={handleSubmit}
-            text="저장"
-            disabled={!canSubmit || !isDirty}
-            isLoading={isSubmitting}
-          />
+          <>
+            {mode === 'UPDATE' && (
+              <NormalButton
+                onClick={() => {
+                  if (isDirty) {
+                    setIsCancelConfirmOpen(true);
+                    return;
+                  }
+                  handleCancelEdit();
+                }}
+                text="취소"
+              />
+            )}
+            <NormalButton
+              onClick={handleSubmit}
+              text="저장"
+              disabled={!canSubmit || !isDirty}
+              isLoading={isSubmitting}
+            />
+          </>
         )}
       </div>
+
+      <ConfirmModal
+        isOpen={isCancelConfirmOpen}
+        title="수정 취소"
+        description="작성한 내용이 초기화됩니다. 되돌리시겠습니까?"
+        confirmText="되돌리기"
+        onConfirm={() => {
+          setIsCancelConfirmOpen(false);
+          handleCancelEdit();
+        }}
+        onCancel={() => setIsCancelConfirmOpen(false)}
+      />
     </div>
   );
 }

--- a/src/pages/course/modal/CourseForm.tsx
+++ b/src/pages/course/modal/CourseForm.tsx
@@ -3,13 +3,7 @@ import {
   LESSON_COUNT,
   WEEKDAY_OPTIONS,
 } from '@/constants/course';
-import {
-  CheckboxGroup,
-  FormField,
-  RadioGroup,
-  Select,
-  TextInput,
-} from '@/shared/form';
+import { CheckboxGroup, FormField, RadioGroup, Select } from '@/shared/form';
 import { useEffect, useState } from 'react';
 import CourseScheduleTimeList from './CourseScheduleTimeList';
 import type { Course, CourseSchedule } from '@/types/course';

--- a/src/pages/course/modal/StudentSearchInput.tsx
+++ b/src/pages/course/modal/StudentSearchInput.tsx
@@ -61,6 +61,26 @@ export default function StudentSearchInput({
           disabled={disabled}
           className="min-w-16"
         />
+        {!disabled && value && !isUserTyping && (
+          <span className="inline-flex items-center gap-1 rounded-full border border-primary bg-primary/10 px-2 py-1 text-xs font-semibold text-primary">
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 12 12"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M2.5 6.2L4.7 8.4L9.5 3.6"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            선택됨
+          </span>
+        )}
       </div>
 
       {open && !disabled && results.length > 0 && (
@@ -68,7 +88,11 @@ export default function StudentSearchInput({
           {results.map((student, index) => (
             <li
               key={`${student.id}-${index}`}
-              className="px-3 py-2 cursor-pointer hover:bg-gray-100"
+              className={`px-3 py-2 cursor-pointer transition-colors ${
+                !isUserTyping && value === student.name
+                  ? 'bg-primary/10 border-l-4 border-primary'
+                  : 'hover:bg-gray-100'
+              }`}
               onClick={() => {
                 onSelect(student);
                 setDraft('');
@@ -76,7 +100,29 @@ export default function StudentSearchInput({
                 setOpen(false);
               }}
             >
-              <div className="font-medium">{student.name}</div>
+              <div className="flex items-center justify-between gap-2">
+                <div className="font-medium">{student.name}</div>
+                {!isUserTyping && value === student.name && (
+                  <span className="inline-flex items-center gap-1 rounded-full border border-primary/40 bg-white px-2 py-0.5 text-[11px] font-semibold text-primary">
+                    <svg
+                      width="10"
+                      height="10"
+                      viewBox="0 0 12 12"
+                      fill="none"
+                      aria-hidden="true"
+                    >
+                      <path
+                        d="M2.5 6.2L4.7 8.4L9.5 3.6"
+                        stroke="currentColor"
+                        strokeWidth="1.6"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                    선택됨
+                  </span>
+                )}
+              </div>
               {student.phone && (
                 <div className="text-xs text-gray-500">{student.phone}</div>
               )}

--- a/src/pages/home/components/DashboardCard.tsx
+++ b/src/pages/home/components/DashboardCard.tsx
@@ -1,0 +1,27 @@
+interface DashboardCardProps {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+function DashboardCard({
+  title,
+  subtitle,
+  children,
+  className = '',
+}: DashboardCardProps) {
+  return (
+    <section
+      className={`rounded-lg border border-gray-200 bg-white p-4 shadow-sm ${className}`}
+    >
+      <div className="mb-3">
+        <h3 className="text-base font-semibold text-gray-900">{title}</h3>
+        {subtitle && <p className="text-xs text-gray-500">{subtitle}</p>}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export default DashboardCard;

--- a/src/pages/home/components/DashboardHeader.tsx
+++ b/src/pages/home/components/DashboardHeader.tsx
@@ -1,0 +1,63 @@
+interface DashboardHeaderProps {
+  cooldownSeconds: number;
+  isRefreshing: boolean;
+  onRefresh: () => void;
+}
+
+function DashboardHeader({
+  cooldownSeconds,
+  isRefreshing,
+  onRefresh,
+}: DashboardHeaderProps) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h2 className="text-xl font-semibold text-gray-900">대시보드</h2>
+        <p className="text-sm text-gray-500">
+          오늘과 이번 달 주요 지표를 한눈에 확인하세요.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onRefresh}
+        disabled={isRefreshing || cooldownSeconds > 0}
+        className={`inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 ${
+          isRefreshing || cooldownSeconds > 0
+            ? 'border-gray-200 text-gray-400 cursor-not-allowed'
+            : 'border-primary text-primary hover:bg-primary/10 active:scale-95 active:bg-primary/20'
+        }`}
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 20 20"
+          fill="none"
+          aria-hidden="true"
+          className={isRefreshing ? 'animate-spin' : ''}
+        >
+          <path
+            d="M16 10a6 6 0 1 1-1.76-4.24"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+          />
+          <path
+            d="M16 4v4h-4"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+        최신화
+        {cooldownSeconds > 0 && (
+          <span className="text-[11px] text-gray-400">
+            {cooldownSeconds}s
+          </span>
+        )}
+      </button>
+    </div>
+  );
+}
+
+export default DashboardHeader;

--- a/src/pages/home/components/SimpleList.tsx
+++ b/src/pages/home/components/SimpleList.tsx
@@ -1,0 +1,23 @@
+interface SimpleListProps<T> {
+  items: T[];
+  emptyText: string;
+  renderItem: (item: T) => React.ReactNode;
+}
+
+function SimpleList<T>({ items, emptyText, renderItem }: SimpleListProps<T>) {
+  if (items.length === 0) {
+    return <p className="text-sm text-gray-400">{emptyText}</p>;
+  }
+
+  return (
+    <ul className="space-y-2">
+      {items.map((item, index) => (
+        <li key={index} className="rounded-md border border-gray-100 p-2">
+          {renderItem(item)}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default SimpleList;

--- a/src/pages/home/components/StatCard.tsx
+++ b/src/pages/home/components/StatCard.tsx
@@ -1,0 +1,19 @@
+interface StatCardProps {
+  title: string;
+  value: number | string;
+  helper?: string;
+}
+
+function StatCard({ title, value, helper }: StatCardProps) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+      <p className="text-xs font-medium text-gray-500">{title}</p>
+      <div className="mt-2 flex items-baseline gap-2">
+        <span className="text-2xl font-semibold text-gray-900">{value}</span>
+        {helper && <span className="text-xs text-gray-400">{helper}</span>}
+      </div>
+    </div>
+  );
+}
+
+export default StatCard;

--- a/src/pages/home/components/WeekdayBarChart.tsx
+++ b/src/pages/home/components/WeekdayBarChart.tsx
@@ -1,0 +1,38 @@
+interface WeekdayBarDatum {
+  label: string;
+  value: number;
+}
+
+interface WeekdayBarChartProps {
+  data: WeekdayBarDatum[];
+}
+
+function WeekdayBarChart({ data }: WeekdayBarChartProps) {
+  const maxValue = Math.max(1, ...data.map((item) => item.value));
+
+  return (
+    <div className="space-y-2">
+      {data.map((item) => {
+        const widthPercent = Math.round((item.value / maxValue) * 100);
+        return (
+          <div key={item.label} className="flex items-center gap-3">
+            <div className="w-6 text-xs text-gray-500">{item.label}</div>
+            <div className="flex-1">
+              <div className="h-2 rounded-full bg-gray-100">
+                <div
+                  className="h-2 rounded-full bg-primary"
+                  style={{ width: `${widthPercent}%` }}
+                />
+              </div>
+            </div>
+            <div className="w-8 text-right text-xs font-medium text-gray-600">
+              {item.value}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default WeekdayBarChart;

--- a/src/pages/home/components/sections/CoursesSection.tsx
+++ b/src/pages/home/components/sections/CoursesSection.tsx
@@ -1,0 +1,46 @@
+import DashboardCard from '../DashboardCard';
+import SimpleList from '../SimpleList';
+import type { Course } from '@/types/course';
+import { formatToKoreanDate } from '@/utils/date/formatKoreanDate';
+import { CLASS_TYPE_OPTIONS } from '@/constants/course';
+
+interface CoursesSectionProps {
+  isLoading: boolean;
+  totalCount: number;
+  courses: Course[];
+}
+
+const getClassTypeLabel = (value: string | null) =>
+  CLASS_TYPE_OPTIONS.find((opt) => opt.value === value)?.label ?? '미지정';
+
+function CoursesSection({ isLoading, totalCount, courses }: CoursesSectionProps) {
+  return (
+    <DashboardCard title="수강 현황" subtitle={`총 ${totalCount}건`}>
+      {isLoading ? (
+        <p className="text-sm text-gray-400">수강 정보를 불러오는 중...</p>
+      ) : (
+        <SimpleList
+          items={courses}
+          emptyText="수강 데이터가 없습니다."
+          renderItem={(course) => (
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold text-gray-900">
+                  {course.student.name}
+                </p>
+                <p className="text-xs text-gray-500">
+                  {getClassTypeLabel(course.class_type)} · {course.lesson_count}회
+                </p>
+              </div>
+              <div className="text-xs text-gray-400">
+                {formatToKoreanDate(course.start_date)}
+              </div>
+            </div>
+          )}
+        />
+      )}
+    </DashboardCard>
+  );
+}
+
+export default CoursesSection;

--- a/src/pages/home/components/sections/LessonDistributionSection.tsx
+++ b/src/pages/home/components/sections/LessonDistributionSection.tsx
@@ -1,0 +1,27 @@
+import DashboardCard from '../DashboardCard';
+import WeekdayBarChart from '../WeekdayBarChart';
+
+interface LessonDistributionSectionProps {
+  isLoading: boolean;
+  weekdayCounts: { label: string; value: number }[];
+}
+
+function LessonDistributionSection({
+  isLoading,
+  weekdayCounts,
+}: LessonDistributionSectionProps) {
+  return (
+    <DashboardCard
+      title="요일별 레슨 분포"
+      subtitle="이번 달 레슨 수를 요일별로 집계했습니다."
+    >
+      {isLoading ? (
+        <p className="text-sm text-gray-400">레슨 데이터를 불러오는 중...</p>
+      ) : (
+        <WeekdayBarChart data={weekdayCounts} />
+      )}
+    </DashboardCard>
+  );
+}
+
+export default LessonDistributionSection;

--- a/src/pages/home/components/sections/LessonSummaryCards.tsx
+++ b/src/pages/home/components/sections/LessonSummaryCards.tsx
@@ -1,0 +1,25 @@
+import StatCard from '../StatCard';
+
+interface LessonSummaryCardsProps {
+  isLoading: boolean;
+  monthTotal: number;
+  todayTotal: number;
+  rolloverTotal: number;
+}
+
+function LessonSummaryCards({
+  isLoading,
+  monthTotal,
+  todayTotal,
+  rolloverTotal,
+}: LessonSummaryCardsProps) {
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+      <StatCard title="이번 달 레슨" value={isLoading ? '...' : monthTotal} helper="건" />
+      <StatCard title="오늘 레슨" value={isLoading ? '...' : todayTotal} helper="건" />
+      <StatCard title="이월 레슨" value={isLoading ? '...' : rolloverTotal} helper="건" />
+    </div>
+  );
+}
+
+export default LessonSummaryCards;

--- a/src/pages/home/components/sections/MessageTemplatesSection.tsx
+++ b/src/pages/home/components/sections/MessageTemplatesSection.tsx
@@ -1,0 +1,55 @@
+import DashboardCard from '../DashboardCard';
+import SimpleList from '../SimpleList';
+import type { MessageTemplate } from '@/types/messageTemplate';
+import { formatToKoreanDate } from '@/utils/date/formatKoreanDate';
+import {
+  MESSAGE_TEMPLATE_TYPE_LABELS,
+  MESSAGE_TEMPLATE_TYPE_STYLES,
+} from '@/constants/messageTemplate';
+
+interface MessageTemplatesSectionProps {
+  isLoading: boolean;
+  totalCount: number;
+  templates: MessageTemplate[];
+}
+
+function MessageTemplatesSection({
+  isLoading,
+  totalCount,
+  templates,
+}: MessageTemplatesSectionProps) {
+  return (
+    <DashboardCard title="메시지 템플릿" subtitle={`총 ${totalCount}개`}>
+      {isLoading ? (
+        <p className="text-sm text-gray-400">템플릿을 불러오는 중...</p>
+      ) : (
+        <SimpleList
+          items={templates}
+          emptyText="템플릿이 없습니다."
+          renderItem={(template) => {
+            const tone = MESSAGE_TEMPLATE_TYPE_STYLES[template.type];
+            return (
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-gray-900">
+                    {template.title}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    {formatToKoreanDate(template.created_at)}
+                  </p>
+                </div>
+                <span
+                  className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${tone.background} ${tone.text} ${tone.border}`}
+                >
+                  {MESSAGE_TEMPLATE_TYPE_LABELS[template.type]}
+                </span>
+              </div>
+            );
+          }}
+        />
+      )}
+    </DashboardCard>
+  );
+}
+
+export default MessageTemplatesSection;

--- a/src/pages/home/components/sections/RolloverLessonSection.tsx
+++ b/src/pages/home/components/sections/RolloverLessonSection.tsx
@@ -1,0 +1,37 @@
+import DashboardCard from '../DashboardCard';
+import SimpleList from '../SimpleList';
+import type { LessonItem } from '@/shared/api/lessons';
+import { formatToKoreanDate } from '@/utils/date/formatKoreanDate';
+
+interface RolloverLessonSectionProps {
+  isLoading: boolean;
+  lessons: LessonItem[];
+}
+
+function RolloverLessonSection({ isLoading, lessons }: RolloverLessonSectionProps) {
+  return (
+    <DashboardCard title="이월 레슨 알림" subtitle="최근 이월 레슨 3건">
+      {isLoading ? (
+        <p className="text-sm text-gray-400">이월 레슨을 불러오는 중...</p>
+      ) : (
+        <SimpleList
+          items={lessons}
+          emptyText="이월 레슨이 없습니다."
+          renderItem={(lesson) => (
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold text-gray-900">{lesson.name}</p>
+                <p className="text-xs text-gray-500">{lesson.lesson_tag}</p>
+              </div>
+              <div className="text-xs text-gray-400">
+                {lesson.start_at ? formatToKoreanDate(lesson.start_at) : '-'}
+              </div>
+            </div>
+          )}
+        />
+      )}
+    </DashboardCard>
+  );
+}
+
+export default RolloverLessonSection;

--- a/src/pages/home/components/sections/StudentsSection.tsx
+++ b/src/pages/home/components/sections/StudentsSection.tsx
@@ -1,0 +1,44 @@
+import DashboardCard from '../DashboardCard';
+import SimpleList from '../SimpleList';
+import type { Student } from '@/types/student';
+import { formatToKoreanDate } from '@/utils/date/formatKoreanDate';
+
+interface StudentsSectionProps {
+  isLoading: boolean;
+  totalCount: number;
+  students: Student[];
+}
+
+function StudentsSection({
+  isLoading,
+  totalCount,
+  students,
+}: StudentsSectionProps) {
+  return (
+    <DashboardCard title="학생 현황" subtitle={`총 ${totalCount}명`}>
+      {isLoading ? (
+        <p className="text-sm text-gray-400">학생 정보를 불러오는 중...</p>
+      ) : (
+        <SimpleList
+          items={students}
+          emptyText="학생 데이터가 없습니다."
+          renderItem={(student) => (
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold text-gray-900">
+                  {student.name}
+                </p>
+                <p className="text-xs text-gray-500">{student.phone}</p>
+              </div>
+              <div className="text-xs text-gray-400">
+                {formatToKoreanDate(student.created_at)}
+              </div>
+            </div>
+          )}
+        />
+      )}
+    </DashboardCard>
+  );
+}
+
+export default StudentsSection;

--- a/src/pages/home/hooks/useCoursesSummary.ts
+++ b/src/pages/home/hooks/useCoursesSummary.ts
@@ -1,39 +1,20 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { getCourses } from '@/shared/api/courses';
-import type { Course } from '@/types/course';
-
-interface CoursesSummary {
-  totalCount: number;
-  courses: Course[];
-  isLoading: boolean;
-}
 
 export const useCoursesSummary = () => {
-  const [summary, setSummary] = useState<CoursesSummary>({
-    totalCount: 0,
-    courses: [],
-    isLoading: true,
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ['home', 'courses', 1, 3],
+    queryFn: () => getCourses({ page: 1, size: 3 }),
   });
 
-  useEffect(() => {
-    let isMounted = true;
-
-    const fetchCourses = async () => {
-      const data = await getCourses({ page: 1, size: 3 });
-      if (!isMounted) return;
-      setSummary({
-        totalCount: data.total_count,
-        courses: data.courses,
-        isLoading: false,
-      });
-    };
-
-    fetchCourses();
-
-    return () => {
-      isMounted = false;
-    };
-  }, []);
-
-  return useMemo(() => summary, [summary]);
+  return useMemo(
+    () => ({
+      totalCount: data?.total_count ?? 0,
+      courses: data?.courses ?? [],
+      isLoading,
+      refetch,
+    }),
+    [data, isLoading, refetch],
+  );
 };

--- a/src/pages/home/hooks/useCoursesSummary.ts
+++ b/src/pages/home/hooks/useCoursesSummary.ts
@@ -1,11 +1,31 @@
 import { useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getCourses } from '@/shared/api/courses';
+import type { GetCoursesResponse } from '@/shared/api/courses/courses.types';
 
 export const useCoursesSummary = () => {
+  const queryClient = useQueryClient();
+  const courseListCache = queryClient.getQueryData<GetCoursesResponse>([
+    'courses',
+    { page: 1, size: 20 },
+  ]);
+  const courseListUpdatedAt = queryClient.getQueryState([
+    'courses',
+    { page: 1, size: 20 },
+  ])?.dataUpdatedAt;
+
   const { data, isLoading, refetch } = useQuery({
     queryKey: ['home', 'courses', 1, 3],
     queryFn: () => getCourses({ page: 1, size: 3 }),
+    initialData: courseListCache
+      ? {
+          ...courseListCache,
+          page: 1,
+          size: 3,
+          courses: courseListCache.courses.slice(0, 3),
+        }
+      : undefined,
+    initialDataUpdatedAt: courseListCache ? courseListUpdatedAt : undefined,
   });
 
   return useMemo(

--- a/src/pages/home/hooks/useCoursesSummary.ts
+++ b/src/pages/home/hooks/useCoursesSummary.ts
@@ -1,0 +1,39 @@
+import { useEffect, useMemo, useState } from 'react';
+import { getCourses } from '@/shared/api/courses';
+import type { Course } from '@/types/course';
+
+interface CoursesSummary {
+  totalCount: number;
+  courses: Course[];
+  isLoading: boolean;
+}
+
+export const useCoursesSummary = () => {
+  const [summary, setSummary] = useState<CoursesSummary>({
+    totalCount: 0,
+    courses: [],
+    isLoading: true,
+  });
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchCourses = async () => {
+      const data = await getCourses({ page: 1, size: 3 });
+      if (!isMounted) return;
+      setSummary({
+        totalCount: data.total_count,
+        courses: data.courses,
+        isLoading: false,
+      });
+    };
+
+    fetchCourses();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return useMemo(() => summary, [summary]);
+};

--- a/src/pages/home/hooks/useLessonSummary.ts
+++ b/src/pages/home/hooks/useLessonSummary.ts
@@ -1,0 +1,80 @@
+import { useEffect, useMemo, useState } from 'react';
+import { getLessons } from '@/shared/api/lessons';
+import { WEEKDAY_OPTIONS } from '@/constants/course';
+import { getWeekdayLabel } from '@/utils/date/getWeekdayLabel';
+import { getWeekdayValueFromDate, toDateKey, type WeekdayValue } from '../utils/date';
+
+interface LessonSummary {
+  monthTotal: number;
+  todayTotal: number;
+  weekdayCounts: { label: string; value: number }[];
+  isLoading: boolean;
+}
+
+export const useLessonSummary = () => {
+  const [summary, setSummary] = useState<LessonSummary>({
+    monthTotal: 0,
+    todayTotal: 0,
+    weekdayCounts: WEEKDAY_OPTIONS.map((opt) => ({
+      label: opt.label,
+      value: 0,
+    })),
+    isLoading: true,
+  });
+
+  useEffect(() => {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = now.getMonth() + 1;
+    const todayKey = toDateKey(now);
+
+    let isMounted = true;
+
+    const fetchLessons = async () => {
+      const data = await getLessons({ year, month });
+      if (!isMounted) return;
+
+      const weekdayMap = new Map<WeekdayValue, number>();
+      WEEKDAY_OPTIONS.forEach((opt) => {
+        weekdayMap.set(opt.value, 0);
+      });
+
+      let monthTotal = 0;
+      let todayTotal = 0;
+
+      data.days.forEach((day) => {
+        const dayTotal = day.lessons.length;
+        monthTotal += dayTotal;
+
+        const parsed = new Date(day.date);
+        if (!Number.isNaN(parsed.getTime())) {
+          const weekday = getWeekdayValueFromDate(parsed);
+          weekdayMap.set(weekday, (weekdayMap.get(weekday) ?? 0) + dayTotal);
+          if (toDateKey(parsed) === todayKey) {
+            todayTotal += dayTotal;
+          }
+        }
+      });
+
+      const weekdayCounts = WEEKDAY_OPTIONS.map((opt) => ({
+        label: getWeekdayLabel(opt.value),
+        value: weekdayMap.get(opt.value) ?? 0,
+      }));
+
+      setSummary({
+        monthTotal,
+        todayTotal,
+        weekdayCounts,
+        isLoading: false,
+      });
+    };
+
+    fetchLessons();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return useMemo(() => summary, [summary]);
+};

--- a/src/pages/home/hooks/useLessonSummary.ts
+++ b/src/pages/home/hooks/useLessonSummary.ts
@@ -1,80 +1,64 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { getLessons } from '@/shared/api/lessons';
 import { WEEKDAY_OPTIONS } from '@/constants/course';
 import { getWeekdayLabel } from '@/utils/date/getWeekdayLabel';
-import { getWeekdayValueFromDate, toDateKey, type WeekdayValue } from '../utils/date';
-
-interface LessonSummary {
-  monthTotal: number;
-  todayTotal: number;
-  weekdayCounts: { label: string; value: number }[];
-  isLoading: boolean;
-}
+import {
+  getWeekdayValueFromDate,
+  toDateKey,
+  type WeekdayValue,
+} from '../utils/date';
 
 export const useLessonSummary = () => {
-  const [summary, setSummary] = useState<LessonSummary>({
-    monthTotal: 0,
-    todayTotal: 0,
-    weekdayCounts: WEEKDAY_OPTIONS.map((opt) => ({
-      label: opt.label,
-      value: 0,
-    })),
-    isLoading: true,
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth() + 1;
+  const todayKey = toDateKey(now);
+
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ['home', 'lessons', year, month],
+    queryFn: () => getLessons({ year, month }),
   });
 
-  useEffect(() => {
-    const now = new Date();
-    const year = now.getFullYear();
-    const month = now.getMonth() + 1;
-    const todayKey = toDateKey(now);
+  return useMemo(() => {
+    const weekdayMap = new Map<WeekdayValue, number>();
+    WEEKDAY_OPTIONS.forEach((opt) => {
+      weekdayMap.set(opt.value, 0);
+    });
 
-    let isMounted = true;
+    let monthTotal = 0;
+    let todayTotal = 0;
 
-    const fetchLessons = async () => {
-      const data = await getLessons({ year, month });
-      if (!isMounted) return;
+    data?.days.forEach((day) => {
+      const dayLessons = day.lessons.filter(
+        (lesson) =>
+          lesson.lesson_tag !== 'rollover' &&
+          lesson.attendance_status !== 'rollover',
+      );
+      const dayTotal = dayLessons.length;
+      monthTotal += dayTotal;
 
-      const weekdayMap = new Map<WeekdayValue, number>();
-      WEEKDAY_OPTIONS.forEach((opt) => {
-        weekdayMap.set(opt.value, 0);
-      });
-
-      let monthTotal = 0;
-      let todayTotal = 0;
-
-      data.days.forEach((day) => {
-        const dayTotal = day.lessons.length;
-        monthTotal += dayTotal;
-
-        const parsed = new Date(day.date);
-        if (!Number.isNaN(parsed.getTime())) {
-          const weekday = getWeekdayValueFromDate(parsed);
-          weekdayMap.set(weekday, (weekdayMap.get(weekday) ?? 0) + dayTotal);
-          if (toDateKey(parsed) === todayKey) {
-            todayTotal += dayTotal;
-          }
+      const parsed = new Date(day.date);
+      if (!Number.isNaN(parsed.getTime())) {
+        const weekday = getWeekdayValueFromDate(parsed);
+        weekdayMap.set(weekday, (weekdayMap.get(weekday) ?? 0) + dayTotal);
+        if (toDateKey(parsed) === todayKey) {
+          todayTotal += dayTotal;
         }
-      });
+      }
+    });
 
-      const weekdayCounts = WEEKDAY_OPTIONS.map((opt) => ({
-        label: getWeekdayLabel(opt.value),
-        value: weekdayMap.get(opt.value) ?? 0,
-      }));
+    const weekdayCounts = WEEKDAY_OPTIONS.map((opt) => ({
+      label: getWeekdayLabel(opt.value),
+      value: weekdayMap.get(opt.value) ?? 0,
+    }));
 
-      setSummary({
-        monthTotal,
-        todayTotal,
-        weekdayCounts,
-        isLoading: false,
-      });
+    return {
+      monthTotal,
+      todayTotal,
+      weekdayCounts,
+      isLoading,
+      refetch,
     };
-
-    fetchLessons();
-
-    return () => {
-      isMounted = false;
-    };
-  }, []);
-
-  return useMemo(() => summary, [summary]);
+  }, [data, isLoading, todayKey, refetch]);
 };

--- a/src/pages/home/hooks/useLessonSummary.ts
+++ b/src/pages/home/hooks/useLessonSummary.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { getLessons } from '@/shared/api/lessons';
+import { getLessons, type GetLessonsResponse } from '@/shared/api/lessons';
 import { WEEKDAY_OPTIONS } from '@/constants/course';
 import { getWeekdayLabel } from '@/utils/date/getWeekdayLabel';
 import {
@@ -16,7 +16,7 @@ export const useLessonSummary = () => {
   const todayKey = toDateKey(now);
 
   const queryClient = useQueryClient();
-  const scheduleCache = queryClient.getQueryData([
+  const scheduleCache = queryClient.getQueryData<GetLessonsResponse>([
     'lessons',
     year,
     month,
@@ -27,7 +27,7 @@ export const useLessonSummary = () => {
     month,
   ])?.dataUpdatedAt;
 
-  const { data, isLoading, refetch } = useQuery({
+  const { data, isLoading, refetch } = useQuery<GetLessonsResponse>({
     queryKey: ['home', 'lessons', year, month],
     queryFn: () => getLessons({ year, month }),
     initialData: scheduleCache,

--- a/src/pages/home/hooks/useLessonSummary.ts
+++ b/src/pages/home/hooks/useLessonSummary.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getLessons } from '@/shared/api/lessons';
 import { WEEKDAY_OPTIONS } from '@/constants/course';
 import { getWeekdayLabel } from '@/utils/date/getWeekdayLabel';
@@ -15,9 +15,23 @@ export const useLessonSummary = () => {
   const month = now.getMonth() + 1;
   const todayKey = toDateKey(now);
 
+  const queryClient = useQueryClient();
+  const scheduleCache = queryClient.getQueryData([
+    'lessons',
+    year,
+    month,
+  ]);
+  const scheduleCacheUpdatedAt = queryClient.getQueryState([
+    'lessons',
+    year,
+    month,
+  ])?.dataUpdatedAt;
+
   const { data, isLoading, refetch } = useQuery({
     queryKey: ['home', 'lessons', year, month],
     queryFn: () => getLessons({ year, month }),
+    initialData: scheduleCache,
+    initialDataUpdatedAt: scheduleCache ? scheduleCacheUpdatedAt : undefined,
   });
 
   return useMemo(() => {

--- a/src/pages/home/hooks/useMessageTemplatesSummary.ts
+++ b/src/pages/home/hooks/useMessageTemplatesSummary.ts
@@ -1,0 +1,39 @@
+import { useEffect, useMemo, useState } from 'react';
+import { getMessageTemplates } from '@/shared/api/message';
+import type { MessageTemplate } from '@/types/messageTemplate';
+
+interface MessageTemplateSummary {
+  totalCount: number;
+  templates: MessageTemplate[];
+  isLoading: boolean;
+}
+
+export const useMessageTemplatesSummary = () => {
+  const [summary, setSummary] = useState<MessageTemplateSummary>({
+    totalCount: 0,
+    templates: [],
+    isLoading: true,
+  });
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchTemplates = async () => {
+      const data = await getMessageTemplates({ page: 1, size: 3 });
+      if (!isMounted) return;
+      setSummary({
+        totalCount: data.total_count,
+        templates: data.templates,
+        isLoading: false,
+      });
+    };
+
+    fetchTemplates();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return useMemo(() => summary, [summary]);
+};

--- a/src/pages/home/hooks/useMessageTemplatesSummary.ts
+++ b/src/pages/home/hooks/useMessageTemplatesSummary.ts
@@ -1,39 +1,20 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { getMessageTemplates } from '@/shared/api/message';
-import type { MessageTemplate } from '@/types/messageTemplate';
-
-interface MessageTemplateSummary {
-  totalCount: number;
-  templates: MessageTemplate[];
-  isLoading: boolean;
-}
 
 export const useMessageTemplatesSummary = () => {
-  const [summary, setSummary] = useState<MessageTemplateSummary>({
-    totalCount: 0,
-    templates: [],
-    isLoading: true,
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ['home', 'message-templates', 1, 3],
+    queryFn: () => getMessageTemplates({ page: 1, size: 3 }),
   });
 
-  useEffect(() => {
-    let isMounted = true;
-
-    const fetchTemplates = async () => {
-      const data = await getMessageTemplates({ page: 1, size: 3 });
-      if (!isMounted) return;
-      setSummary({
-        totalCount: data.total_count,
-        templates: data.templates,
-        isLoading: false,
-      });
-    };
-
-    fetchTemplates();
-
-    return () => {
-      isMounted = false;
-    };
-  }, []);
-
-  return useMemo(() => summary, [summary]);
+  return useMemo(
+    () => ({
+      totalCount: data?.total_count ?? 0,
+      templates: data?.templates ?? [],
+      isLoading,
+      refetch,
+    }),
+    [data, isLoading, refetch],
+  );
 };

--- a/src/pages/home/hooks/useRolloverLessons.ts
+++ b/src/pages/home/hooks/useRolloverLessons.ts
@@ -1,40 +1,20 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { getRollOverLessons } from '@/shared/api/lessons';
-import type { LessonItem } from '@/shared/api/lessons';
-
-interface RolloverSummary {
-  totalCount: number;
-  lessons: LessonItem[];
-  isLoading: boolean;
-}
 
 export const useRolloverLessons = () => {
-  const [summary, setSummary] = useState<RolloverSummary>({
-    totalCount: 0,
-    lessons: [],
-    isLoading: true,
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ['home', 'rollover-lessons'],
+    queryFn: () => getRollOverLessons(),
   });
 
-  useEffect(() => {
-    let isMounted = true;
-
-    const fetchRolloverLessons = async () => {
-      const data = await getRollOverLessons();
-      if (!isMounted) return;
-
-      setSummary({
-        totalCount: data.total_count,
-        lessons: data.lessons.slice(0, 3),
-        isLoading: false,
-      });
-    };
-
-    fetchRolloverLessons();
-
-    return () => {
-      isMounted = false;
-    };
-  }, []);
-
-  return useMemo(() => summary, [summary]);
+  return useMemo(
+    () => ({
+      totalCount: data?.total_count ?? 0,
+      lessons: data?.lessons.slice(0, 3) ?? [],
+      isLoading,
+      refetch,
+    }),
+    [data, isLoading, refetch],
+  );
 };

--- a/src/pages/home/hooks/useRolloverLessons.ts
+++ b/src/pages/home/hooks/useRolloverLessons.ts
@@ -1,0 +1,40 @@
+import { useEffect, useMemo, useState } from 'react';
+import { getRollOverLessons } from '@/shared/api/lessons';
+import type { LessonItem } from '@/shared/api/lessons';
+
+interface RolloverSummary {
+  totalCount: number;
+  lessons: LessonItem[];
+  isLoading: boolean;
+}
+
+export const useRolloverLessons = () => {
+  const [summary, setSummary] = useState<RolloverSummary>({
+    totalCount: 0,
+    lessons: [],
+    isLoading: true,
+  });
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchRolloverLessons = async () => {
+      const data = await getRollOverLessons();
+      if (!isMounted) return;
+
+      setSummary({
+        totalCount: data.total_count,
+        lessons: data.lessons.slice(0, 3),
+        isLoading: false,
+      });
+    };
+
+    fetchRolloverLessons();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return useMemo(() => summary, [summary]);
+};

--- a/src/pages/home/hooks/useStudentsSummary.ts
+++ b/src/pages/home/hooks/useStudentsSummary.ts
@@ -1,0 +1,39 @@
+import { useEffect, useMemo, useState } from 'react';
+import { getStudents } from '@/shared/api/students';
+import type { Student } from '@/types/student';
+
+interface StudentsSummary {
+  totalCount: number;
+  students: Student[];
+  isLoading: boolean;
+}
+
+export const useStudentsSummary = () => {
+  const [summary, setSummary] = useState<StudentsSummary>({
+    totalCount: 0,
+    students: [],
+    isLoading: true,
+  });
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchStudents = async () => {
+      const data = await getStudents({ page: 1, size: 3 });
+      if (!isMounted) return;
+      setSummary({
+        totalCount: data.total_count,
+        students: data.students,
+        isLoading: false,
+      });
+    };
+
+    fetchStudents();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return useMemo(() => summary, [summary]);
+};

--- a/src/pages/home/hooks/useStudentsSummary.ts
+++ b/src/pages/home/hooks/useStudentsSummary.ts
@@ -1,11 +1,32 @@
 import { useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getStudents } from '@/shared/api/students';
+import type { GetStudentsResponse } from '@/shared/api/students';
 
 export const useStudentsSummary = () => {
+  const queryClient = useQueryClient();
+  const studentListCache = queryClient.getQueryData<GetStudentsResponse>([
+    'students',
+    { page: 1, size: 20 },
+  ]);
+  const studentListUpdatedAt = queryClient.getQueryState([
+    'students',
+    { page: 1, size: 20 },
+  ])?.dataUpdatedAt;
+
   const { data, isLoading, refetch } = useQuery({
     queryKey: ['home', 'students', 1, 3],
     queryFn: () => getStudents({ page: 1, size: 3 }),
+    initialData: studentListCache
+      ? {
+          ...studentListCache,
+          page: 1,
+          size: 3,
+          students: studentListCache.students.slice(0, 3),
+        }
+      : undefined,
+    initialDataUpdatedAt: studentListCache ? studentListUpdatedAt : undefined,
+    staleTime: 1000 * 60 * 5,
   });
 
   return useMemo(

--- a/src/pages/home/hooks/useStudentsSummary.ts
+++ b/src/pages/home/hooks/useStudentsSummary.ts
@@ -1,39 +1,20 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { getStudents } from '@/shared/api/students';
-import type { Student } from '@/types/student';
-
-interface StudentsSummary {
-  totalCount: number;
-  students: Student[];
-  isLoading: boolean;
-}
 
 export const useStudentsSummary = () => {
-  const [summary, setSummary] = useState<StudentsSummary>({
-    totalCount: 0,
-    students: [],
-    isLoading: true,
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ['home', 'students', 1, 3],
+    queryFn: () => getStudents({ page: 1, size: 3 }),
   });
 
-  useEffect(() => {
-    let isMounted = true;
-
-    const fetchStudents = async () => {
-      const data = await getStudents({ page: 1, size: 3 });
-      if (!isMounted) return;
-      setSummary({
-        totalCount: data.total_count,
-        students: data.students,
-        isLoading: false,
-      });
-    };
-
-    fetchStudents();
-
-    return () => {
-      isMounted = false;
-    };
-  }, []);
-
-  return useMemo(() => summary, [summary]);
+  return useMemo(
+    () => ({
+      totalCount: data?.total_count ?? 0,
+      students: data?.students ?? [],
+      isLoading,
+      refetch,
+    }),
+    [data, isLoading, refetch],
+  );
 };

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,8 +1,186 @@
+import DashboardCard from './components/DashboardCard';
+import SimpleList from './components/SimpleList';
+import StatCard from './components/StatCard';
+import WeekdayBarChart from './components/WeekdayBarChart';
+import { useLessonSummary } from './hooks/useLessonSummary';
+import { useRolloverLessons } from './hooks/useRolloverLessons';
+import { useCoursesSummary } from './hooks/useCoursesSummary';
+import { useStudentsSummary } from './hooks/useStudentsSummary';
+import { useMessageTemplatesSummary } from './hooks/useMessageTemplatesSummary';
+import { formatToKoreanDate } from '@/utils/date/formatKoreanDate';
+import { CLASS_TYPE_OPTIONS } from '@/constants/course';
+import {
+  MESSAGE_TEMPLATE_TYPE_LABELS,
+  MESSAGE_TEMPLATE_TYPE_STYLES,
+} from '@/constants/messageTemplate';
+
+const getClassTypeLabel = (value: string | null) =>
+  CLASS_TYPE_OPTIONS.find((opt) => opt.value === value)?.label ?? '미지정';
+
 function HomePage() {
+  const lessonSummary = useLessonSummary();
+  const rolloverSummary = useRolloverLessons();
+  const coursesSummary = useCoursesSummary();
+  const studentsSummary = useStudentsSummary();
+  const templatesSummary = useMessageTemplatesSummary();
+
   return (
-    <div>
-      <p>Home Page (테스트입니다)</p>
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold text-gray-900">대시보드</h2>
+        <p className="text-sm text-gray-500">
+          오늘과 이번 달 주요 지표를 한눈에 확인하세요.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <StatCard
+          title="이번 달 레슨"
+          value={lessonSummary.isLoading ? '...' : lessonSummary.monthTotal}
+          helper="건"
+        />
+        <StatCard
+          title="오늘 레슨"
+          value={lessonSummary.isLoading ? '...' : lessonSummary.todayTotal}
+          helper="건"
+        />
+        <StatCard
+          title="이월 레슨"
+          value={rolloverSummary.isLoading ? '...' : rolloverSummary.totalCount}
+          helper="건"
+        />
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+        <DashboardCard
+          title="요일별 레슨 분포"
+          subtitle="이번 달 레슨 수를 요일별로 집계했습니다."
+        >
+          {lessonSummary.isLoading ? (
+            <p className="text-sm text-gray-400">레슨 데이터를 불러오는 중...</p>
+          ) : (
+            <WeekdayBarChart data={lessonSummary.weekdayCounts} />
+          )}
+        </DashboardCard>
+
+        <DashboardCard title="이월 레슨 알림" subtitle="최근 이월 레슨 3건">
+          {rolloverSummary.isLoading ? (
+            <p className="text-sm text-gray-400">이월 레슨을 불러오는 중...</p>
+          ) : (
+            <SimpleList
+              items={rolloverSummary.lessons}
+              emptyText="이월 레슨이 없습니다."
+              renderItem={(lesson) => (
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-gray-900">
+                      {lesson.name}
+                    </p>
+                    <p className="text-xs text-gray-500">{lesson.lesson_tag}</p>
+                  </div>
+                  <div className="text-xs text-gray-400">
+                    {lesson.start_at ? formatToKoreanDate(lesson.start_at) : '-'}
+                  </div>
+                </div>
+              )}
+            />
+          )}
+        </DashboardCard>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
+        <DashboardCard
+          title="수강 현황"
+          subtitle={`총 ${coursesSummary.totalCount}건`}
+        >
+          {coursesSummary.isLoading ? (
+            <p className="text-sm text-gray-400">수강 정보를 불러오는 중...</p>
+          ) : (
+            <SimpleList
+              items={coursesSummary.courses}
+              emptyText="수강 데이터가 없습니다."
+              renderItem={(course) => (
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-gray-900">
+                      {course.student.name}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {getClassTypeLabel(course.class_type)} · {course.lesson_count}회
+                    </p>
+                  </div>
+                  <div className="text-xs text-gray-400">
+                    {formatToKoreanDate(course.start_date)}
+                  </div>
+                </div>
+              )}
+            />
+          )}
+        </DashboardCard>
+
+        <DashboardCard
+          title="학생 현황"
+          subtitle={`총 ${studentsSummary.totalCount}명`}
+        >
+          {studentsSummary.isLoading ? (
+            <p className="text-sm text-gray-400">학생 정보를 불러오는 중...</p>
+          ) : (
+            <SimpleList
+              items={studentsSummary.students}
+              emptyText="학생 데이터가 없습니다."
+              renderItem={(student) => (
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-gray-900">
+                      {student.name}
+                    </p>
+                    <p className="text-xs text-gray-500">{student.phone}</p>
+                  </div>
+                  <div className="text-xs text-gray-400">
+                    {formatToKoreanDate(student.created_at)}
+                  </div>
+                </div>
+              )}
+            />
+          )}
+        </DashboardCard>
+
+        <DashboardCard
+          title="메시지 템플릿"
+          subtitle={`총 ${templatesSummary.totalCount}개`}
+        >
+          {templatesSummary.isLoading ? (
+            <p className="text-sm text-gray-400">템플릿을 불러오는 중...</p>
+          ) : (
+            <SimpleList
+              items={templatesSummary.templates}
+              emptyText="템플릿이 없습니다."
+              renderItem={(template) => {
+                const tone = MESSAGE_TEMPLATE_TYPE_STYLES[template.type];
+                return (
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-gray-900">
+                        {template.title}
+                      </p>
+                      <p className="text-xs text-gray-500">
+                        {formatToKoreanDate(template.created_at)}
+                      </p>
+                    </div>
+                    <span
+                      className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${tone.background} ${tone.text} ${tone.border}`}
+                    >
+                      {MESSAGE_TEMPLATE_TYPE_LABELS[template.type]}
+                    </span>
+                  </div>
+                );
+              }}
+            />
+          )}
+        </DashboardCard>
+      </div>
     </div>
   );
 }
+
 export default HomePage;

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,21 +1,16 @@
-import DashboardCard from './components/DashboardCard';
-import SimpleList from './components/SimpleList';
-import StatCard from './components/StatCard';
-import WeekdayBarChart from './components/WeekdayBarChart';
+import DashboardHeader from './components/DashboardHeader';
 import { useLessonSummary } from './hooks/useLessonSummary';
 import { useRolloverLessons } from './hooks/useRolloverLessons';
 import { useCoursesSummary } from './hooks/useCoursesSummary';
 import { useStudentsSummary } from './hooks/useStudentsSummary';
 import { useMessageTemplatesSummary } from './hooks/useMessageTemplatesSummary';
-import { formatToKoreanDate } from '@/utils/date/formatKoreanDate';
-import { CLASS_TYPE_OPTIONS } from '@/constants/course';
-import {
-  MESSAGE_TEMPLATE_TYPE_LABELS,
-  MESSAGE_TEMPLATE_TYPE_STYLES,
-} from '@/constants/messageTemplate';
-
-const getClassTypeLabel = (value: string | null) =>
-  CLASS_TYPE_OPTIONS.find((opt) => opt.value === value)?.label ?? '미지정';
+import { useEffect, useRef, useState } from 'react';
+import LessonSummaryCards from './components/sections/LessonSummaryCards';
+import LessonDistributionSection from './components/sections/LessonDistributionSection';
+import RolloverLessonSection from './components/sections/RolloverLessonSection';
+import CoursesSection from './components/sections/CoursesSection';
+import StudentsSection from './components/sections/StudentsSection';
+import MessageTemplatesSection from './components/sections/MessageTemplatesSection';
 
 function HomePage() {
   const lessonSummary = useLessonSummary();
@@ -23,161 +18,92 @@ function HomePage() {
   const coursesSummary = useCoursesSummary();
   const studentsSummary = useStudentsSummary();
   const templatesSummary = useMessageTemplatesSummary();
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [cooldownSeconds, setCooldownSeconds] = useState(0);
+  const cooldownTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (cooldownSeconds <= 0) {
+      if (cooldownTimerRef.current !== null) {
+        window.clearInterval(cooldownTimerRef.current);
+        cooldownTimerRef.current = null;
+      }
+      return;
+    }
+
+    if (cooldownTimerRef.current === null) {
+      cooldownTimerRef.current = window.setInterval(() => {
+        setCooldownSeconds((prev) => Math.max(0, prev - 1));
+      }, 1000);
+    }
+
+    return () => {
+      if (cooldownTimerRef.current !== null) {
+        window.clearInterval(cooldownTimerRef.current);
+        cooldownTimerRef.current = null;
+      }
+    };
+  }, [cooldownSeconds]);
+
+  const handleRefresh = async () => {
+    if (isRefreshing || cooldownSeconds > 0) return;
+    setIsRefreshing(true);
+    await Promise.all([
+      lessonSummary.refetch(),
+      rolloverSummary.refetch(),
+      coursesSummary.refetch(),
+      studentsSummary.refetch(),
+      templatesSummary.refetch(),
+    ]);
+    setIsRefreshing(false);
+    setCooldownSeconds(30);
+  };
 
   return (
     <div className="space-y-6">
-      <div>
-        <h2 className="text-xl font-semibold text-gray-900">대시보드</h2>
-        <p className="text-sm text-gray-500">
-          오늘과 이번 달 주요 지표를 한눈에 확인하세요.
-        </p>
-      </div>
+      <DashboardHeader
+        cooldownSeconds={cooldownSeconds}
+        isRefreshing={isRefreshing}
+        onRefresh={handleRefresh}
+      />
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-        <StatCard
-          title="이번 달 레슨"
-          value={lessonSummary.isLoading ? '...' : lessonSummary.monthTotal}
-          helper="건"
-        />
-        <StatCard
-          title="오늘 레슨"
-          value={lessonSummary.isLoading ? '...' : lessonSummary.todayTotal}
-          helper="건"
-        />
-        <StatCard
-          title="이월 레슨"
-          value={rolloverSummary.isLoading ? '...' : rolloverSummary.totalCount}
-          helper="건"
-        />
-      </div>
+      <LessonSummaryCards
+        isLoading={lessonSummary.isLoading || rolloverSummary.isLoading}
+        monthTotal={lessonSummary.monthTotal}
+        todayTotal={lessonSummary.todayTotal}
+        rolloverTotal={rolloverSummary.totalCount}
+      />
 
       <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
-        <DashboardCard
-          title="요일별 레슨 분포"
-          subtitle="이번 달 레슨 수를 요일별로 집계했습니다."
-        >
-          {lessonSummary.isLoading ? (
-            <p className="text-sm text-gray-400">레슨 데이터를 불러오는 중...</p>
-          ) : (
-            <WeekdayBarChart data={lessonSummary.weekdayCounts} />
-          )}
-        </DashboardCard>
+        <LessonDistributionSection
+          isLoading={lessonSummary.isLoading}
+          weekdayCounts={lessonSummary.weekdayCounts}
+        />
 
-        <DashboardCard title="이월 레슨 알림" subtitle="최근 이월 레슨 3건">
-          {rolloverSummary.isLoading ? (
-            <p className="text-sm text-gray-400">이월 레슨을 불러오는 중...</p>
-          ) : (
-            <SimpleList
-              items={rolloverSummary.lessons}
-              emptyText="이월 레슨이 없습니다."
-              renderItem={(lesson) => (
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <p className="text-sm font-semibold text-gray-900">
-                      {lesson.name}
-                    </p>
-                    <p className="text-xs text-gray-500">{lesson.lesson_tag}</p>
-                  </div>
-                  <div className="text-xs text-gray-400">
-                    {lesson.start_at ? formatToKoreanDate(lesson.start_at) : '-'}
-                  </div>
-                </div>
-              )}
-            />
-          )}
-        </DashboardCard>
+        <RolloverLessonSection
+          isLoading={rolloverSummary.isLoading}
+          lessons={rolloverSummary.lessons}
+        />
       </div>
 
       <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
-        <DashboardCard
-          title="수강 현황"
-          subtitle={`총 ${coursesSummary.totalCount}건`}
-        >
-          {coursesSummary.isLoading ? (
-            <p className="text-sm text-gray-400">수강 정보를 불러오는 중...</p>
-          ) : (
-            <SimpleList
-              items={coursesSummary.courses}
-              emptyText="수강 데이터가 없습니다."
-              renderItem={(course) => (
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <p className="text-sm font-semibold text-gray-900">
-                      {course.student.name}
-                    </p>
-                    <p className="text-xs text-gray-500">
-                      {getClassTypeLabel(course.class_type)} · {course.lesson_count}회
-                    </p>
-                  </div>
-                  <div className="text-xs text-gray-400">
-                    {formatToKoreanDate(course.start_date)}
-                  </div>
-                </div>
-              )}
-            />
-          )}
-        </DashboardCard>
+        <CoursesSection
+          isLoading={coursesSummary.isLoading}
+          totalCount={coursesSummary.totalCount}
+          courses={coursesSummary.courses}
+        />
 
-        <DashboardCard
-          title="학생 현황"
-          subtitle={`총 ${studentsSummary.totalCount}명`}
-        >
-          {studentsSummary.isLoading ? (
-            <p className="text-sm text-gray-400">학생 정보를 불러오는 중...</p>
-          ) : (
-            <SimpleList
-              items={studentsSummary.students}
-              emptyText="학생 데이터가 없습니다."
-              renderItem={(student) => (
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <p className="text-sm font-semibold text-gray-900">
-                      {student.name}
-                    </p>
-                    <p className="text-xs text-gray-500">{student.phone}</p>
-                  </div>
-                  <div className="text-xs text-gray-400">
-                    {formatToKoreanDate(student.created_at)}
-                  </div>
-                </div>
-              )}
-            />
-          )}
-        </DashboardCard>
+        <StudentsSection
+          isLoading={studentsSummary.isLoading}
+          totalCount={studentsSummary.totalCount}
+          students={studentsSummary.students}
+        />
 
-        <DashboardCard
-          title="메시지 템플릿"
-          subtitle={`총 ${templatesSummary.totalCount}개`}
-        >
-          {templatesSummary.isLoading ? (
-            <p className="text-sm text-gray-400">템플릿을 불러오는 중...</p>
-          ) : (
-            <SimpleList
-              items={templatesSummary.templates}
-              emptyText="템플릿이 없습니다."
-              renderItem={(template) => {
-                const tone = MESSAGE_TEMPLATE_TYPE_STYLES[template.type];
-                return (
-                  <div className="flex items-center justify-between gap-3">
-                    <div>
-                      <p className="text-sm font-semibold text-gray-900">
-                        {template.title}
-                      </p>
-                      <p className="text-xs text-gray-500">
-                        {formatToKoreanDate(template.created_at)}
-                      </p>
-                    </div>
-                    <span
-                      className={`rounded-full border px-2 py-0.5 text-[11px] font-semibold ${tone.background} ${tone.text} ${tone.border}`}
-                    >
-                      {MESSAGE_TEMPLATE_TYPE_LABELS[template.type]}
-                    </span>
-                  </div>
-                );
-              }}
-            />
-          )}
-        </DashboardCard>
+        <MessageTemplatesSection
+          isLoading={templatesSummary.isLoading}
+          totalCount={templatesSummary.totalCount}
+          templates={templatesSummary.templates}
+        />
       </div>
     </div>
   );

--- a/src/pages/home/utils/date.tsx
+++ b/src/pages/home/utils/date.tsx
@@ -1,0 +1,9 @@
+const WEEKDAY_VALUES = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'] as const;
+
+export type WeekdayValue = (typeof WEEKDAY_VALUES)[number];
+
+export const getWeekdayValueFromDate = (date: Date): WeekdayValue =>
+  WEEKDAY_VALUES[date.getDay()];
+
+export const toDateKey = (value: Date) =>
+  `${value.getFullYear()}-${String(value.getMonth() + 1).padStart(2, '0')}-${String(value.getDate()).padStart(2, '0')}`;

--- a/src/pages/message/send/StudentList/hooks/useStudents.ts
+++ b/src/pages/message/send/StudentList/hooks/useStudents.ts
@@ -1,24 +1,32 @@
-import { useEffect, useState } from 'react';
-import { api } from '@/shared/api/axios';
-import type { Student } from '@/types/student';
+import { useMemo } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { getStudents } from '@/shared/api/students';
+import type { GetStudentsResponse } from '@/shared/api/students';
 
 export const useStudents = () => {
-  const [students, setStudents] = useState<Student[]>([]);
+  const queryClient = useQueryClient();
+  const studentListCache = queryClient.getQueryData<GetStudentsResponse>([
+    'students',
+    { page: 1, size: 20 },
+  ]);
+  const studentListUpdatedAt = queryClient.getQueryState([
+    'students',
+    { page: 1, size: 20 },
+  ])?.dataUpdatedAt;
 
-  useEffect(() => {
-    const fetchStudents = async () => {
-      try {
-        const response = await api.get('/students');
-        if (response.data.students && response.data.students.length > 0) {
-          setStudents(response.data.students);
-        }
-      } catch (error) {
-        console.error('Failed to fetch student:', error);
-      }
-    };
+  const { data } = useQuery({
+    queryKey: ['students', { page: 1, size: 20 }],
+    queryFn: () => getStudents({ page: 1, size: 20 }),
+    initialData: studentListCache,
+    initialDataUpdatedAt: studentListCache ? studentListUpdatedAt : undefined,
+    staleTime: 1000 * 60 * 5,
+    refetchOnMount: (query) => query.isStale(),
+  });
 
-    fetchStudents();
-  }, []);
-
-  return { students };
+  return useMemo(
+    () => ({
+      students: data?.students ?? [],
+    }),
+    [data],
+  );
 };

--- a/src/pages/schedule/header/components/CarryListSection/components/CarryListModal/hooks/useCarryList.ts
+++ b/src/pages/schedule/header/components/CarryListSection/components/CarryListModal/hooks/useCarryList.ts
@@ -1,25 +1,34 @@
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 import { getRollOverLessons, type LessonItem } from '@/shared/api/lessons';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import type { GetRolloverLessonsResponse } from '@/shared/api/lessons';
 
 // 이월 목록을 관리하는 커스텀 훅 - 이월된 레슨 목록을 가져오고 상태로 관리
 export const useCarryList = () => {
-  // 이월된 레슨 목록
-  const [lessons, setLessons] = useState<LessonItem[]>([]);
+  const queryClient = useQueryClient();
+  const homeCache = queryClient.getQueryData<GetRolloverLessonsResponse>([
+    'home',
+    'rollover-lessons',
+  ]);
+  const homeCacheUpdatedAt = queryClient.getQueryState([
+    'home',
+    'rollover-lessons',
+  ])?.dataUpdatedAt;
 
-  // 이월된 레슨 목록을 API에서 가져오는 함수
-  const fetchLessons = async () => {
-    try {
-      const response = await getRollOverLessons();
-      setLessons(response.lessons);
-    } catch (error) {
-      console.error('Failed to fetch roll-over lessons:', error);
-    }
-  };
+  const { data, refetch } = useQuery({
+    queryKey: ['rollover-lessons'],
+    queryFn: () => getRollOverLessons(),
+    initialData: homeCache,
+    initialDataUpdatedAt: homeCache ? homeCacheUpdatedAt : undefined,
+    staleTime: 1000 * 60 * 5,
+    refetchOnMount: (query) => query.isStale(),
+  });
 
-  // 컴포넌트가 마운트될 때 이월된 레슨 목록을 가져옴
-  useEffect(() => {
-    fetchLessons();
-  }, []);
-
-  return { lessons, fetchLessons };
+  return useMemo(
+    () => ({
+      lessons: (data?.lessons ?? []) as LessonItem[],
+      fetchLessons: refetch,
+    }),
+    [data, refetch],
+  );
 };

--- a/src/pages/schedule/header/components/CarryListSection/components/CarryListModal/hooks/useCarryList.ts
+++ b/src/pages/schedule/header/components/CarryListSection/components/CarryListModal/hooks/useCarryList.ts
@@ -27,7 +27,9 @@ export const useCarryList = () => {
   return useMemo(
     () => ({
       lessons: (data?.lessons ?? []) as LessonItem[],
-      fetchLessons: refetch,
+      fetchLessons: async () => {
+        await refetch();
+      },
     }),
     [data, refetch],
   );

--- a/src/pages/schedule/header/components/CarryListSection/index.tsx
+++ b/src/pages/schedule/header/components/CarryListSection/index.tsx
@@ -4,7 +4,7 @@ import CarryListModal from './components/CarryListModal';
 import { useCarryModalStore } from '@/store/schedule/carryModalStore';
 
 interface CarryListSectionProps {
-  onRefreshLessons: () => Promise<void>;
+  onRefreshLessons: () => void;
 }
 // 이월 목록 버튼과 모달을 포함하는 헤더의 오른쪽 섹션 컴포넌트
 function CarryListSection({ onRefreshLessons }: CarryListSectionProps) {

--- a/src/pages/schedule/header/components/CarryListSection/index.tsx
+++ b/src/pages/schedule/header/components/CarryListSection/index.tsx
@@ -4,7 +4,7 @@ import CarryListModal from './components/CarryListModal';
 import { useCarryModalStore } from '@/store/schedule/carryModalStore';
 
 interface CarryListSectionProps {
-  onRefreshLessons: () => void;
+  onRefreshLessons: () => Promise<void>;
 }
 // 이월 목록 버튼과 모달을 포함하는 헤더의 오른쪽 섹션 컴포넌트
 function CarryListSection({ onRefreshLessons }: CarryListSectionProps) {

--- a/src/pages/schedule/header/index.tsx
+++ b/src/pages/schedule/header/index.tsx
@@ -2,7 +2,7 @@ import CarryListSection from './components/CarryListSection';
 import SelectMonthSection from './components/SelectMonthSection';
 
 interface CalendarHeaderProps {
-  onRefreshLessons: () => void;
+  onRefreshLessons: () => Promise<void>;
   isRefreshing?: boolean;
 }
 

--- a/src/pages/schedule/header/index.tsx
+++ b/src/pages/schedule/header/index.tsx
@@ -2,18 +2,55 @@ import CarryListSection from './components/CarryListSection';
 import SelectMonthSection from './components/SelectMonthSection';
 
 interface CalendarHeaderProps {
-  onRefreshLessons: () => Promise<void>;
+  onRefreshLessons: () => void;
+  isRefreshing?: boolean;
 }
 
 // 캘린더 헤더 컴포넌트 - 월 선택과 이월 목록 버튼을 포함
-function CalendarHeader({ onRefreshLessons }: CalendarHeaderProps) {
+function CalendarHeader({ onRefreshLessons, isRefreshing }: CalendarHeaderProps) {
   return (
-    <div className="flex justify-between items-center">
+    <div className="flex flex-wrap items-center justify-between gap-2">
       {/* 1. 월 선택 섹션과 이월 목록 섹션을 포함하는 헤더 레이아웃 */}
       <SelectMonthSection />
 
       {/* 2. 이월 목록 버튼과 모달을 포함하는 섹션 */}
-      <CarryListSection onRefreshLessons={onRefreshLessons} />
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onRefreshLessons}
+          disabled={isRefreshing}
+          className={`inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 ${
+            isRefreshing
+              ? 'border-gray-200 text-gray-400 cursor-not-allowed'
+              : 'border-primary text-primary hover:bg-primary/10 active:scale-95 active:bg-primary/20'
+          }`}
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 20 20"
+            fill="none"
+            aria-hidden="true"
+            className={isRefreshing ? 'animate-spin' : ''}
+          >
+            <path
+              d="M16 10a6 6 0 1 1-1.76-4.24"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+            />
+            <path
+              d="M16 4v4h-4"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          최신화
+        </button>
+        <CarryListSection onRefreshLessons={onRefreshLessons} />
+      </div>
     </div>
   );
 }

--- a/src/pages/schedule/hooks/useScheduleCalendar.ts
+++ b/src/pages/schedule/hooks/useScheduleCalendar.ts
@@ -1,8 +1,10 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { CalendarData } from '@/types/schedule';
 import { getLessons } from '@/shared/api/lessons';
 import { getClassTypeLabel } from '@/utils/course/getClassTypeLabel';
 import { useScheduleCalendarStore } from '@/store/schedule/scheduleCalendarStore';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import type { GetLessonsResponse } from '@/shared/api/lessons';
 
 /*
  * 캘린더 데이터를 관리하는 커스텀 훅
@@ -13,6 +15,20 @@ import { useScheduleCalendarStore } from '@/store/schedule/scheduleCalendarStore
 export const useScheduleCalendar = () => {
   const { currentMonth, currentYear } = useScheduleCalendarStore(); // 캘린더 상태 (현재 연도, 월)
   const [calendarData, setCalendarData] = useState<CalendarData>({}); // 캘린더 데이터 상태
+  const queryClient = useQueryClient();
+  const month = currentMonth + 1;
+  const homeLessonsCache = queryClient.getQueryData<GetLessonsResponse>([
+    'home',
+    'lessons',
+    currentYear,
+    month,
+  ]);
+  const homeLessonsUpdatedAt = queryClient.getQueryState([
+    'home',
+    'lessons',
+    currentYear,
+    month,
+  ])?.dataUpdatedAt;
 
   // 출석 상태 업데이트 핸들러
   const handleAttendanceUpdated = (
@@ -38,13 +54,8 @@ export const useScheduleCalendar = () => {
   };
 
   // 회차 데이터 불러오기
-  const fetchLessons = useCallback(async () => {
-    const response = await getLessons({
-      year: currentYear,
-      month: currentMonth + 1,
-    });
-
-    const data: CalendarData = response.days.reduce((acc, day) => {
+  const mapLessonsToCalendar = useCallback((response: GetLessonsResponse) => {
+    return response.days.reduce((acc, day) => {
       acc[day.date] = {
         date: day.date,
         lessons: day.lessons.map((lesson) => ({
@@ -65,19 +76,36 @@ export const useScheduleCalendar = () => {
       };
       return acc;
     }, {} as CalendarData);
+  }, []);
 
-    setCalendarData(data);
-  }, [currentMonth, currentYear]);
+  const { data, isFetching, refetch } = useQuery({
+    queryKey: ['lessons', currentYear, month],
+    queryFn: () => getLessons({ year: currentYear, month }),
+    initialData: homeLessonsCache,
+    initialDataUpdatedAt: homeLessonsCache ? homeLessonsUpdatedAt : undefined,
+    staleTime: 1000 * 60 * 5,
+    refetchOnMount: (query) => query.isStale(),
+  });
+
+  const fetchLessons = useCallback(() => {
+    refetch();
+  }, [refetch]);
 
   // 컴포넌트 마운트 시 회차 데이터 불러오기
+  const mappedData = useMemo(
+    () => (data ? mapLessonsToCalendar(data) : {}),
+    [data, mapLessonsToCalendar],
+  );
+
   useEffect(() => {
-    fetchLessons();
-  }, [fetchLessons]);
+    setCalendarData(mappedData);
+  }, [mappedData]);
 
   // 외부로 노출할 데이터와 함수
   return {
     calendarData,
     fetchLessons,
     handleAttendanceUpdated,
+    isRefreshing: isFetching,
   };
 };

--- a/src/pages/schedule/hooks/useScheduleCalendar.ts
+++ b/src/pages/schedule/hooks/useScheduleCalendar.ts
@@ -87,8 +87,8 @@ export const useScheduleCalendar = () => {
     refetchOnMount: (query) => query.isStale(),
   });
 
-  const fetchLessons = useCallback(() => {
-    refetch();
+  const fetchLessons = useCallback(async () => {
+    await refetch();
   }, [refetch]);
 
   // 컴포넌트 마운트 시 회차 데이터 불러오기

--- a/src/pages/schedule/index.tsx
+++ b/src/pages/schedule/index.tsx
@@ -4,13 +4,16 @@ import { useScheduleCalendar } from './hooks/useScheduleCalendar';
 
 // 스케줄 관리 페이지 컴포넌트
 function SchedulePage() {
-  const { calendarData, fetchLessons, handleAttendanceUpdated } =
+  const { calendarData, fetchLessons, handleAttendanceUpdated, isRefreshing } =
     useScheduleCalendar(); // 캘린더 데이터와 관련 함수들을 커스텀 훅에서 가져옴
 
   return (
     <div>
       {/* 1. 캘린더 헤더 (월 이동, 오늘 버튼) */}
-      <CalendarHeader onRefreshLessons={fetchLessons} />
+      <CalendarHeader
+        onRefreshLessons={fetchLessons}
+        isRefreshing={isRefreshing}
+      />
 
       {/* 2. 캘린더 본문 */}
       <CalendarGrid

--- a/src/pages/student/components/StudentDetailModal/components/StudentCreateForm.tsx
+++ b/src/pages/student/components/StudentDetailModal/components/StudentCreateForm.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import NormalButton from '@/shared/button/NormalButton';
 import { createStudent } from '@/shared/api/students';
+import ConfirmModal from '@/shared/modal/ConfirmModal';
 import { useStudentModalStore } from '@/store/student/studentModalStore';
 import StudentFormFields from './shared/StudentFormFields';
 import {
@@ -21,6 +22,7 @@ function StudentCreateForm({
 }: StudentCreateFormProps) {
   const { close } = useStudentModalStore(); // 모달 닫기 함수
   const [form, setForm] = useState<StudentFormState>(INITIAL_FORM); // 폼 상태 관리
+  const [isResetConfirmOpen, setIsResetConfirmOpen] = useState(false);
   const isDirty = JSON.stringify(form) !== JSON.stringify(INITIAL_FORM); // 폼이 초기 상태에서 변경되었는지 여부
 
   // 폼 상태가 변경될 때마다 부모 컴포넌트에 변경 여부 알리기
@@ -74,13 +76,33 @@ function StudentCreateForm({
       <StudentFormFields form={form} onChange={updateForm} />
 
       {/* 2. 저장 버튼 */}
-      <div className="w-full flex justify-end">
+      <div className="w-full flex justify-end gap-2">
+        <NormalButton
+          onClick={() => {
+            setIsResetConfirmOpen(true);
+          }}
+          text="초기화"
+          disabled={!isDirty}
+        />
         <NormalButton
           onClick={handleSubmit}
           text="저장"
           disabled={!canSubmit}
         />
       </div>
+
+      <ConfirmModal
+        isOpen={isResetConfirmOpen}
+        title="초기화"
+        description="초기화 하시겠습니까?"
+        confirmText="초기화"
+        onConfirm={() => {
+          setForm(INITIAL_FORM);
+          onDirtyChange(false);
+          setIsResetConfirmOpen(false);
+        }}
+        onCancel={() => setIsResetConfirmOpen(false)}
+      />
     </div>
   );
 }

--- a/src/pages/student/components/StudentDetailModal/components/StudentDetailView.tsx
+++ b/src/pages/student/components/StudentDetailModal/components/StudentDetailView.tsx
@@ -1,6 +1,7 @@
 import type { Student } from '@/types/student';
 import { useEffect, useState } from 'react';
 import NormalButton from '@/shared/button/NormalButton';
+import ConfirmModal from '@/shared/modal/ConfirmModal';
 import { updateStudent } from '@/shared/api/students';
 import { useStudentModalStore } from '@/store/student/studentModalStore';
 import { useInvoiceModalStore } from '@/store/invoice/invoiceModalStore';
@@ -28,6 +29,7 @@ function StudentDetailView({
   const [originalForm, setOriginalForm] =
     useState<StudentFormState>(mappedStudent); // 원본 폼 상태 저장 (수정 취소 시 사용)
   const [form, setForm] = useState<StudentFormState>(mappedStudent); // 현재 폼 상태
+  const [isCancelConfirmOpen, setIsCancelConfirmOpen] = useState(false);
   const { mode, openUpdate, openDetail } = useStudentModalStore(); // 모달 상태에서 현재 모드와 학생 상세/수정 오픈 함수 가져오기
   const isEditMode = mode === 'UPDATE'; //
 
@@ -131,11 +133,32 @@ function StudentDetailView({
                 onClick={handleSave}
                 disabled={!isDirty}
               />
-              <NormalButton text="취소" onClick={handleCancelEdit} />
+              <NormalButton
+                text="취소"
+                onClick={() => {
+                  if (isDirty) {
+                    setIsCancelConfirmOpen(true);
+                    return;
+                  }
+                  handleCancelEdit();
+                }}
+              />
             </>
           )}
         </div>
       </div>
+
+      <ConfirmModal
+        isOpen={isCancelConfirmOpen}
+        title="수정 취소"
+        description="수정한 내용이 초기화됩니다. 되돌리시겠습니까?"
+        confirmText="되돌리기"
+        onConfirm={() => {
+          setIsCancelConfirmOpen(false);
+          handleCancelEdit();
+        }}
+        onCancel={() => setIsCancelConfirmOpen(false)}
+      />
     </div>
   );
 }

--- a/src/pages/student/index.tsx
+++ b/src/pages/student/index.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import TableSection from '../../shared/modal/TableSection';
 import { getStudents } from '@/shared/api/students';
 import type { Student } from '@/types/student';
@@ -8,6 +7,8 @@ import ModalOpenButton from '@/shared/modal/ModalOpenButton';
 import { getAgeGroupLabel } from '@/utils/student/getAgeGroupLabel';
 import InvoiceListModal from './components/InvoiceListModal';
 import Chip from '@/shared/chip/Chip';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import type { GetStudentsResponse } from '@/shared/api/students';
 
 const getAgeGroupTone = (ageGroup: Student['age_group'] | null) => {
   const normalized = ageGroup ? String(ageGroup).toUpperCase() : '';
@@ -31,25 +32,73 @@ const getAgeGroupTone = (ageGroup: Student['age_group'] | null) => {
 function StudentPage() {
   // 학생 모달 상태 관리
   const { isOpen, openCreate, openDetail } = useStudentModalStore();
-  // 학생 목록 상태 관리
-  const [students, setStudents] = useState<Student[]>([]);
+  const queryClient = useQueryClient();
+  const homeCache = queryClient.getQueryData<GetStudentsResponse>([
+    'home',
+    'students',
+    1,
+    3,
+  ]);
+  const homeCacheUpdatedAt = queryClient.getQueryState([
+    'home',
+    'students',
+    1,
+    3,
+  ])?.dataUpdatedAt;
 
-  // 학생 목록을 API에서 불러오는 함수
-  const loadStudents = async () => {
-    const { students } = await getStudents({ page: 1, size: 20 });
-    setStudents(students);
-  };
+  const { data, isFetching, refetch } = useQuery({
+    queryKey: ['students', { page: 1, size: 20 }],
+    queryFn: () => getStudents({ page: 1, size: 20 }),
+    initialData: homeCache
+      ? { ...homeCache, page: 1, size: 20 }
+      : undefined,
+    initialDataUpdatedAt: homeCache ? homeCacheUpdatedAt : undefined,
+    staleTime: 1000 * 60 * 5,
+    refetchOnMount: (query) => query.isStale(),
+  });
 
-  // 컴포넌트가 마운트될 때 학생 목록 불러오기
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    loadStudents();
-  }, []);
+  const students = data?.students ?? [];
 
   return (
     <div>
       {/* 1. 헤더 */}
-      <ModalOpenButton text="신규학생 추가" openModal={openCreate} />
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <ModalOpenButton text="신규학생 추가" openModal={openCreate} />
+        <button
+          type="button"
+          onClick={() => refetch()}
+          disabled={isFetching}
+          className={`inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 ${
+            isFetching
+              ? 'border-gray-200 text-gray-400 cursor-not-allowed'
+              : 'border-primary text-primary hover:bg-primary/10 active:scale-95 active:bg-primary/20'
+          }`}
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 20 20"
+            fill="none"
+            aria-hidden="true"
+            className={isFetching ? 'animate-spin' : ''}
+          >
+            <path
+              d="M16 10a6 6 0 1 1-1.76-4.24"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+            />
+            <path
+              d="M16 4v4h-4"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          최신화
+        </button>
+      </div>
 
       {/* 2. 테이블 */}
       <TableSection<Student>
@@ -78,7 +127,7 @@ function StudentPage() {
       />
 
       {/* 3-1. 학생 상세 모달 */}
-      {isOpen && <StudentModal onSuccess={loadStudents} />}
+      {isOpen && <StudentModal onSuccess={refetch} />}
       {/* 3-2. 청구서 목록 모달 */}
       <InvoiceListModal />
     </div>

--- a/src/shared/form/NumberInput.tsx
+++ b/src/shared/form/NumberInput.tsx
@@ -14,28 +14,53 @@ function NumberInput({
   formatter,
 }: NumberInputProps) {
   return (
-    <input
-      type="text"
-      inputMode="numeric"
-      value={value}
-      placeholder={placeholder}
-      disabled={disabled}
-      onChange={(e) => {
-        if (disabled) return;
-        const nextValue = formatter
-          ? formatter(e.target.value)
-          : e.target.value.replace(/\D/g, '');
-        onChange?.(nextValue);
-      }}
-      className={`
-        placeholder:text-sm border flex-1 rounded-sm pl-2 py-1
-        ${
-          disabled
-            ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
-            : 'border-primary text-primary'
-        }
-      `}
-    />
+    <div className="relative">
+      <input
+        type="text"
+        inputMode="numeric"
+        value={value}
+        placeholder={placeholder}
+        disabled={disabled}
+        onChange={(e) => {
+          if (disabled) return;
+          const nextValue = formatter
+            ? formatter(e.target.value)
+            : e.target.value.replace(/\D/g, '');
+          onChange?.(nextValue);
+        }}
+        className={`
+          placeholder:text-sm border flex-1 rounded-sm pl-2 pr-8 py-1 w-full
+          ${
+            disabled
+              ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
+              : 'border-primary text-primary'
+          }
+        `}
+      />
+      {value && !disabled && (
+        <button
+          type="button"
+          aria-label="입력값 초기화"
+          onClick={() => onChange?.('')}
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-primary/70 hover:text-primary"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 20 20"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M6 6L14 14M14 6L6 14"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+      )}
+    </div>
   );
 }
 

--- a/src/shared/form/NumberInput.tsx
+++ b/src/shared/form/NumberInput.tsx
@@ -28,7 +28,7 @@ function NumberInput({
         onChange?.(nextValue);
       }}
       className={`
-        border flex-1 rounded-sm pl-2 py-1
+        placeholder:text-sm border flex-1 rounded-sm pl-2 py-1
         ${
           disabled
             ? 'bg-gray-100 text-gray-400 cursor-not-allowed'

--- a/src/shared/form/RadioGroup.tsx
+++ b/src/shared/form/RadioGroup.tsx
@@ -17,24 +17,57 @@ function RadioGroup<T extends string>({
   disabled = false,
 }: RadioGroupProps<T>) {
   return (
-    <div className="flex gap-4">
-      {options.map((opt) => (
-        <label
-          key={opt.value}
-          className={`flex items-center gap-1 ${
-            disabled ? 'text-gray-400 cursor-not-allowed' : ''
-          }`}
-        >
-          <input
-            type="radio"
-            value={opt.value}
-            checked={value === opt.value}
+    <div className="flex gap-2">
+      {options.map((opt) => {
+        const isActive = value === opt.value;
+        return (
+          <button
+            type="button"
+            key={opt.value}
             disabled={disabled}
-            onChange={() => onChange?.(opt.value)}
-          />
-          {opt.label}
-        </label>
-      ))}
+            onClick={() => onChange?.(opt.value)}
+            aria-pressed={isActive}
+            className={`flex items-center gap-2 rounded-sm border px-4 py-1.5 text-sm font-semibold transition-all ${
+              disabled
+                ? isActive
+                  ? 'border-primary/30 bg-primary-light text-primary'
+                  : 'border-primary/20 bg-gray-100 text-gray-400'
+                : isActive
+                  ? 'border-primary bg-primary text-white shadow-sm'
+                  : 'border-primary text-gray-600 hover:bg-primary/10 hover:text-primary'
+            }`}
+          >
+            <span
+              className={`flex h-4 w-4 items-center justify-center rounded-full border ${
+                isActive
+                  ? disabled
+                    ? 'border-primary text-primary'
+                    : 'border-white text-white'
+                  : 'border-current text-current'
+              }`}
+            >
+              {isActive ? (
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 12 12"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M2.5 6.2L4.7 8.4L9.5 3.6"
+                    stroke="currentColor"
+                    strokeWidth="1.6"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              ) : null}
+            </span>
+            {opt.label}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/shared/form/Select.tsx
+++ b/src/shared/form/Select.tsx
@@ -93,12 +93,18 @@ function Select({ options, value, onChange, disabled = false }: SelectProps) {
         onClick={() => !disabled && setIsOpen((prev) => !prev)}
         className={` w-full rounded-sm border px-2 py-1.5 text-left text-sm transition-colors ${
           disabled
-            ? 'bg-gray-100 text-gray-400 cursor-not-allowed border-gray-200'
+            ? 'bg-gray-100 text-gray-400 cursor-not-allowed border-gray-400'
             : 'bg-white text-primary border-primary hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
         }`}
       >
-        <span className="text-primary">{selectedLabel}</span>
-        <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-primary">
+        <span className={disabled ? 'text-gray-400' : 'text-primary'}>
+          {selectedLabel}
+        </span>
+        <span
+          className={`pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 ${
+            disabled ? 'text-gray-400' : 'text-primary'
+          }`}
+        >
           <svg
             width="14"
             height="14"

--- a/src/shared/form/Select.tsx
+++ b/src/shared/form/Select.tsx
@@ -42,15 +42,21 @@ function Select({ options, value, onChange, disabled = false }: SelectProps) {
       }
     };
 
-    const handleClose = () => setIsOpen(false);
+    const handleScroll = (event: Event) => {
+      const target = event.target as Node | null;
+      if (target && menuRef.current?.contains(target)) {
+        return;
+      }
+      setIsOpen(false);
+    };
 
     window.addEventListener('pointerdown', handlePointerDown);
-    window.addEventListener('scroll', handleClose, true);
-    window.addEventListener('resize', handleClose);
+    window.addEventListener('scroll', handleScroll, true);
+    window.addEventListener('resize', handleScroll);
     return () => {
       window.removeEventListener('pointerdown', handlePointerDown);
-      window.removeEventListener('scroll', handleClose, true);
-      window.removeEventListener('resize', handleClose);
+      window.removeEventListener('scroll', handleScroll, true);
+      window.removeEventListener('resize', handleScroll);
     };
   }, [isOpen]);
 
@@ -76,7 +82,7 @@ function Select({ options, value, onChange, disabled = false }: SelectProps) {
       setMenuStyle({
         top,
         left: rect.left,
-        width: rect.width,
+        width: Math.max(rect.width, 160),
       });
     };
 
@@ -139,8 +145,10 @@ function Select({ options, value, onChange, disabled = false }: SelectProps) {
                   0,
                 width:
                   menuStyle?.width ??
-                  triggerRef.current?.getBoundingClientRect().width ??
-                  0,
+                  Math.max(
+                    triggerRef.current?.getBoundingClientRect().width ?? 0,
+                    160,
+                  ),
                 visibility: menuStyle ? 'visible' : 'hidden',
                 pointerEvents: menuStyle ? 'auto' : 'none',
               }}

--- a/src/shared/form/Select.tsx
+++ b/src/shared/form/Select.tsx
@@ -1,3 +1,6 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
 interface SelectOption {
   label: string;
   value: string;
@@ -11,27 +14,166 @@ interface SelectProps {
 }
 
 function Select({ options, value, onChange, disabled = false }: SelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const [menuStyle, setMenuStyle] = useState<{
+    top: number;
+    left: number;
+    width: number;
+  } | null>(null);
+
+  const selectedLabel = useMemo(
+    () => options.find((opt) => opt.value === value)?.label ?? '선택',
+    [options, value],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+      if (!target) return;
+      const inDropdown = dropdownRef.current?.contains(target) ?? false;
+      const inMenu = menuRef.current?.contains(target) ?? false;
+      if (!inDropdown && !inMenu) {
+        setIsOpen(false);
+      }
+    };
+
+    const handleClose = () => setIsOpen(false);
+
+    window.addEventListener('pointerdown', handlePointerDown);
+    window.addEventListener('scroll', handleClose, true);
+    window.addEventListener('resize', handleClose);
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDown);
+      window.removeEventListener('scroll', handleClose, true);
+      window.removeEventListener('resize', handleClose);
+    };
+  }, [isOpen]);
+
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+    setMenuStyle(null);
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+    const rect = trigger.getBoundingClientRect();
+    const measure = () => {
+      const menuHeight = menuRef.current?.offsetHeight ?? 0;
+      const spaceBelow = window.innerHeight - rect.bottom;
+      const spaceAbove = rect.top;
+      const nextDirection =
+        menuHeight > 0 && spaceBelow < menuHeight && spaceAbove > spaceBelow
+          ? 'up'
+          : 'down';
+      const gap = 8;
+      const top =
+        nextDirection === 'up'
+          ? Math.max(gap, rect.top - menuHeight - gap)
+          : Math.min(window.innerHeight - menuHeight - gap, rect.bottom + gap);
+      setMenuStyle({
+        top,
+        left: rect.left,
+        width: rect.width,
+      });
+    };
+
+    const raf = requestAnimationFrame(measure);
+    return () => cancelAnimationFrame(raf);
+  }, [isOpen]);
+
   return (
-    <select
-      value={value}
-      disabled={disabled}
-      onChange={(e) => onChange?.(e.target.value)}
-      className={`
-        border rounded-sm py-1 px-2
-        ${
+    <div className="relative" ref={dropdownRef}>
+      <button
+        type="button"
+        ref={triggerRef}
+        disabled={disabled}
+        onClick={() => !disabled && setIsOpen((prev) => !prev)}
+        className={` w-full rounded-sm border px-2 py-1.5 text-left text-sm transition-colors ${
           disabled
-            ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
-            : 'border-primary text-primary'
-        }
-      `}
-    >
-      <option value="">선택</option>
-      {options.map((opt) => (
-        <option key={opt.value} value={opt.value}>
-          {opt.label}
-        </option>
-      ))}
-    </select>
+            ? 'bg-gray-100 text-gray-400 cursor-not-allowed border-gray-200'
+            : 'bg-white text-primary border-primary hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
+        }`}
+      >
+        <span className="text-primary">{selectedLabel}</span>
+        <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-primary">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 20 20"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M5 7.5L10 12.5L15 7.5"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </span>
+      </button>
+
+      {isOpen && !disabled
+        ? createPortal(
+            <div
+              ref={menuRef}
+              className="fixed z-50 max-h-64 overflow-auto rounded-md border border-gray-200 bg-white shadow-lg"
+              style={{
+                top:
+                  menuStyle?.top ??
+                  triggerRef.current?.getBoundingClientRect().bottom ??
+                  0,
+                left:
+                  menuStyle?.left ??
+                  triggerRef.current?.getBoundingClientRect().left ??
+                  0,
+                width:
+                  menuStyle?.width ??
+                  triggerRef.current?.getBoundingClientRect().width ??
+                  0,
+                visibility: menuStyle ? 'visible' : 'hidden',
+                pointerEvents: menuStyle ? 'auto' : 'none',
+              }}
+            >
+              <button
+                type="button"
+                onClick={() => {
+                  onChange?.('');
+                  setIsOpen(false);
+                }}
+                className={`w-full px-3 py-2 text-left text-sm transition-colors ${
+                  value === '' ? 'bg-gray-50 text-gray-900' : 'text-gray-600'
+                } hover:bg-gray-50`}
+              >
+                선택
+              </button>
+              {options.map((opt) => {
+                const isActive = opt.value === value;
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => {
+                      onChange?.(opt.value);
+                      setIsOpen(false);
+                    }}
+                    className={`w-full px-3 py-2 text-left text-sm transition-colors ${
+                      isActive ? 'bg-primary/10 text-primary' : 'text-gray-700'
+                    } hover:bg-gray-50`}
+                  >
+                    {opt.label}
+                  </button>
+                );
+              })}
+            </div>,
+            document.body,
+          )
+        : null}
+    </div>
   );
 }
 

--- a/src/shared/form/TextInput.tsx
+++ b/src/shared/form/TextInput.tsx
@@ -14,21 +14,46 @@ function TextInput({
   disabled = false,
 }: TextInputProps) {
   return (
-    <input
-      type={type}
-      value={value}
-      placeholder={placeholder}
-      disabled={disabled}
-      onChange={(e) => onChange?.(e.target.value)}
-      className={`
-        border flex-1 rounded-sm pl-2 py-1
-        ${
-          disabled
-            ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
-            : 'border-primary text-primary'
-        }
-      `}
-    />
+    <div className="relative">
+      <input
+        type={type}
+        value={value}
+        placeholder={placeholder}
+        disabled={disabled}
+        onChange={(e) => onChange?.(e.target.value)}
+        className={`
+          border flex-1 rounded-sm pl-2 pr-8 py-1 w-full
+          ${
+            disabled
+              ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
+              : 'border-primary text-primary'
+          }
+        `}
+      />
+      {value && !disabled && (
+        <button
+          type="button"
+          aria-label="입력값 초기화"
+          onClick={() => onChange?.('')}
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-primary/70 hover:text-primary"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 20 20"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M6 6L14 14M14 6L6 14"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+      )}
+    </div>
   );
 }
 

--- a/src/shared/form/Textarea.tsx
+++ b/src/shared/form/Textarea.tsx
@@ -6,19 +6,44 @@ interface TextareaProps {
 
 function Textarea({ value, onChange, disabled = false }: TextareaProps) {
   return (
-    <textarea
-      value={value}
-      disabled={disabled}
-      onChange={(e) => onChange?.(e.target.value)}
-      className={`
-        border rounded-sm p-2 w-full
-        ${
-          disabled
-            ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
-            : 'border-primary text-primary'
-        }
-      `}
-    />
+    <div className="relative">
+      <textarea
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange?.(e.target.value)}
+        className={`
+          border rounded-sm p-2 pr-8 w-full resize-none
+          ${
+            disabled
+              ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
+              : 'border-primary text-primary'
+          }
+        `}
+      />
+      {value && !disabled && (
+        <button
+          type="button"
+          aria-label="입력값 초기화"
+          onClick={() => onChange?.('')}
+          className="absolute right-2 top-2 text-primary/70 hover:text-primary"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 20 20"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M6 6L14 14M14 6L6 14"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
**요약**
- 폼 입력/선택 UI 전반을 커스텀 드롭다운·라디오·인풋 개선으로 정리해 사용성을 높였습니다.
- 홈/학생/과정/스케줄 화면에 캐시와 새로고침 흐름을 추가해 데이터 갱신 경험을 강화했습니다.

**주요 변경사항**
- 기본 `select`를 커스텀 드롭다운으로 교체하고 비활성 색상 및 내부 스크롤 동작을 보정했습니다.
- 학생 폼 리셋 확인, 취소 확인 문구 정리 등 폼 상호작용을 개선했습니다.
- 인풋 클리어 버튼 추가, 숫자 입력 placeholder 크기 조정 등 입력 UX를 다듬었습니다.
- 학생 검색 선택 강조, 과정 수정 시 학생 선택 잠금 등 선택 흐름을 보완했습니다.
- 과정 수정의 날짜/취소 흐름을 개선하고 관련 동작을 정리했습니다.
- 홈 대시보드를 기존 API 기반으로 구성하고 새로고침 컨트롤을 추가했습니다.
- 학생/과정/스케줄 화면에 캐시 및 새로고침/스테일 캐싱을 도입했습니다.
- 학생 리스트 캐시를 홈/메시지 전송 등에서 재사용하도록 리팩터링했습니다.
- 레슨 새로고침 타입 정합성을 맞춰 빌드 오류를 해소했습니다.

**테스트/확인 포인트**
- 커스텀 드롭다운이 비활성/스크롤 상황에서도 정상 동작하는지 확인
- 학생 폼 리셋 확인 및 취소 확인 문구 노출이 의도대로 동작하는지 확인
- 인풋 클리어 버튼/숫자 placeholder 크기가 디자인 의도대로 보이는지 확인
- 학생 검색 선택 강조 및 과정 수정 시 선택 잠금이 유지되는지 확인
- 홈/학생/과정/스케줄 화면의 캐시/새로고침 동작이 정상인지 확인
- 테스트 실행하지 않음