### PR TITLE
대시보드 캐시 분리·재사용 개선 및 수강 관리 모바일 카드 레이아웃 추가

### DIFF
--- a/src/pages/course/index.tsx
+++ b/src/pages/course/index.tsx
@@ -10,8 +10,7 @@ import { formatToKoreanDate } from '@/utils/date/formatKoreanDate';
 import { getClassTypeLabel } from '@/utils/course/getClassTypeLabel';
 import { getCourses } from '@/shared/api/courses';
 import Chip from '@/shared/chip/Chip';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import type { GetCoursesResponse } from '@/shared/api/courses/courses.types';
+import { useQuery } from '@tanstack/react-query';
 
 const formatToHourMinute = (time?: string) => {
   if (!time) return '';
@@ -35,27 +34,9 @@ const getInvoiceChipProps = (status: Course['invoice']['status']) =>
 
 function CoursePage() {
   const { isOpen, openCreate, openDetail } = useCourseModalStore();
-  const queryClient = useQueryClient();
-  const homeCache = queryClient.getQueryData<GetCoursesResponse>([
-    'home',
-    'courses',
-    1,
-    3,
-  ]);
-  const homeCacheUpdatedAt = queryClient.getQueryState([
-    'home',
-    'courses',
-    1,
-    3,
-  ])?.dataUpdatedAt;
-
   const { data, isFetching, refetch } = useQuery({
     queryKey: ['courses', { page: 1, size: 20 }],
     queryFn: () => getCourses({ page: 1, size: 20 }),
-    initialData: homeCache
-      ? { ...homeCache, page: 1, size: 20 }
-      : undefined,
-    initialDataUpdatedAt: homeCache ? homeCacheUpdatedAt : undefined,
     staleTime: 1000 * 60 * 5,
     refetchOnMount: (query) => query.isStale(),
   });

--- a/src/pages/course/index.tsx
+++ b/src/pages/course/index.tsx
@@ -42,6 +42,7 @@ function CoursePage() {
   });
 
   const courses = data?.courses ?? [];
+  const isEmpty = courses.length === 0;
   return (
     <div>
       <div className="flex flex-wrap items-center justify-between gap-2">
@@ -81,45 +82,110 @@ function CoursePage() {
           최신화
         </button>
       </div>
-      <TableSection<Course>
-        dataList={courses}
-        headers={[
-          '이름',
-          '클래스',
-          '수강 회차',
-          '수강 요일 & 시간',
-          '결제상태',
-          '결제일',
-        ]}
-        getRows={(courses) => {
-          if (!courses || courses.length === 0) return [];
-          return courses.map((course) => [
-            course.student?.name ?? '',
-            course.class_type ? (
-              <Chip
-                label={getClassTypeLabel(course.class_type)}
-                tone={getClassTone(course.class_type)}
-              />
-            ) : (
-              ''
-            ),
-            <Chip label={`${course.lesson_count}회`} tone="slate" />,
-            course.schedules?.length
-              ? course.schedules
-                  .map(
-                    (schedule) =>
-                      `${getWeekdayLabel(schedule.weekday)} ${formatToHourMinute(schedule.time)}`,
-                  )
-                  .join(', ')
-              : '',
-            <Chip {...getInvoiceChipProps(course.invoice?.status)} />,
-            course.invoice?.paid_at
-              ? formatToKoreanDate(course.invoice?.paid_at)
-              : '-',
-          ]);
-        }}
-        onRowClick={(course) => openDetail(course)}
-      />
+      {isEmpty ? (
+        <div className="py-10 text-center text-gray-500">
+          <p>조회 내용이 없습니다.</p>
+        </div>
+      ) : (
+        <>
+          <div className="mt-4 grid gap-3 lg:hidden">
+            {courses.map((course) => {
+              const scheduleText = course.schedules?.length
+                ? course.schedules
+                    .map(
+                      (schedule) =>
+                        `${getWeekdayLabel(schedule.weekday)} ${formatToHourMinute(schedule.time)}`,
+                    )
+                    .join(', ')
+                : '-';
+
+              return (
+                <button
+                  key={course.id}
+                  type="button"
+                  onClick={() => openDetail(course)}
+                  className="w-full rounded-2xl border border-gray-100 bg-white px-4 py-3 text-left shadow-sm transition active:scale-[0.99]"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="text-base font-semibold text-gray-800">
+                      {course.student?.name ?? ''}
+                    </div>
+                    <Chip {...getInvoiceChipProps(course.invoice?.status)} />
+                  </div>
+                  <div className="mt-2 flex flex-wrap items-center gap-2">
+                    {course.class_type ? (
+                      <Chip
+                        label={getClassTypeLabel(course.class_type)}
+                        tone={getClassTone(course.class_type)}
+                      />
+                    ) : null}
+                    <Chip label={`${course.lesson_count}회`} tone="slate" />
+                  </div>
+                  <div className="mt-3 space-y-1 text-sm text-gray-600">
+                    <div className="flex items-start gap-2">
+                      <span className="text-xs font-semibold text-gray-400">
+                        요일/시간
+                      </span>
+                      <span className="flex-1">{scheduleText}</span>
+                    </div>
+                    <div className="flex items-start gap-2">
+                      <span className="text-xs font-semibold text-gray-400">
+                        결제일
+                      </span>
+                      <span className="flex-1">
+                        {course.invoice?.paid_at
+                          ? formatToKoreanDate(course.invoice?.paid_at)
+                          : '-'}
+                      </span>
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+          <div className="hidden lg:block">
+            <TableSection<Course>
+              dataList={courses}
+              headers={[
+                '이름',
+                '클래스',
+                '수강 회차',
+                '수강 요일 & 시간',
+                '결제상태',
+                '결제일',
+              ]}
+              getRows={(courses) => {
+                if (!courses || courses.length === 0) return [];
+                return courses.map((course) => [
+                  course.student?.name ?? '',
+                  course.class_type ? (
+                    <Chip
+                      label={getClassTypeLabel(course.class_type)}
+                      tone={getClassTone(course.class_type)}
+                    />
+                  ) : (
+                    ''
+                  ),
+                  <Chip label={`${course.lesson_count}회`} tone="slate" />,
+                  course.schedules?.length
+                    ? course.schedules
+                        .map(
+                          (schedule) =>
+                            `${getWeekdayLabel(schedule.weekday)} ${formatToHourMinute(schedule.time)}`,
+                        )
+                        .join(', ')
+                    : '',
+                  <Chip {...getInvoiceChipProps(course.invoice?.status)} />,
+                  course.invoice?.paid_at
+                    ? formatToKoreanDate(course.invoice?.paid_at)
+                    : '-',
+                ]);
+              }}
+              onRowClick={(course) => openDetail(course)}
+            />
+          </div>
+        </>
+      )}
       {isOpen && <CourseModal onSuccess={refetch} />}
     </div>
   );

--- a/src/pages/home/hooks/useCoursesSummary.ts
+++ b/src/pages/home/hooks/useCoursesSummary.ts
@@ -1,11 +1,32 @@
 import { useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { getCourses } from '@/shared/api/courses';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { getCourses, type GetCoursesResponse } from '@/shared/api/courses';
 
 export const useCoursesSummary = () => {
-  const { data, isLoading, refetch } = useQuery({
+  const queryClient = useQueryClient();
+  const coursesCache = queryClient.getQueryData<GetCoursesResponse>([
+    'courses',
+    { page: 1, size: 20 },
+  ]);
+  const coursesCacheUpdatedAt = queryClient.getQueryState([
+    'courses',
+    { page: 1, size: 20 },
+  ])?.dataUpdatedAt;
+  const hasEnoughCache = (coursesCache?.courses.length ?? 0) >= 3;
+  const initialData = hasEnoughCache
+    ? {
+        ...coursesCache,
+        size: 3,
+        courses: coursesCache?.courses.slice(0, 3) ?? [],
+      }
+    : undefined;
+
+  const { data, isLoading, refetch } = useQuery<GetCoursesResponse>({
     queryKey: ['home', 'courses', 1, 3],
     queryFn: () => getCourses({ page: 1, size: 3 }),
+    enabled: !hasEnoughCache,
+    initialData,
+    initialDataUpdatedAt: initialData ? coursesCacheUpdatedAt : undefined,
   });
 
   return useMemo(

--- a/src/pages/home/hooks/useCoursesSummary.ts
+++ b/src/pages/home/hooks/useCoursesSummary.ts
@@ -1,31 +1,11 @@
 import { useMemo } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { getCourses } from '@/shared/api/courses';
-import type { GetCoursesResponse } from '@/shared/api/courses/courses.types';
 
 export const useCoursesSummary = () => {
-  const queryClient = useQueryClient();
-  const courseListCache = queryClient.getQueryData<GetCoursesResponse>([
-    'courses',
-    { page: 1, size: 20 },
-  ]);
-  const courseListUpdatedAt = queryClient.getQueryState([
-    'courses',
-    { page: 1, size: 20 },
-  ])?.dataUpdatedAt;
-
   const { data, isLoading, refetch } = useQuery({
     queryKey: ['home', 'courses', 1, 3],
     queryFn: () => getCourses({ page: 1, size: 3 }),
-    initialData: courseListCache
-      ? {
-          ...courseListCache,
-          page: 1,
-          size: 3,
-          courses: courseListCache.courses.slice(0, 3),
-        }
-      : undefined,
-    initialDataUpdatedAt: courseListCache ? courseListUpdatedAt : undefined,
   });
 
   return useMemo(

--- a/src/pages/home/hooks/useMessageTemplatesSummary.ts
+++ b/src/pages/home/hooks/useMessageTemplatesSummary.ts
@@ -1,11 +1,26 @@
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { getMessageTemplates } from '@/shared/api/message';
+import { getMessageTemplates, type GetMessageTemplatesResponse } from '@/shared/api/message';
+import { useMessageTemplateStore } from '@/store/message/messageTemplateStore';
 
 export const useMessageTemplatesSummary = () => {
-  const { data, isLoading, refetch } = useQuery({
+  const templatesCache = useMessageTemplateStore((state) => state.templates);
+  const totalCountCache = useMessageTemplateStore((state) => state.totalCount);
+  const hasEnoughCache = templatesCache.length >= 3 && totalCountCache > 0;
+  const initialData: GetMessageTemplatesResponse | undefined = hasEnoughCache
+    ? {
+        total_count: totalCountCache,
+        page: 1,
+        size: 3,
+        templates: templatesCache.slice(0, 3),
+      }
+    : undefined;
+
+  const { data, isLoading, refetch } = useQuery<GetMessageTemplatesResponse>({
     queryKey: ['home', 'message-templates', 1, 3],
     queryFn: () => getMessageTemplates({ page: 1, size: 3 }),
+    enabled: !hasEnoughCache,
+    initialData,
   });
 
   return useMemo(

--- a/src/pages/home/hooks/useStudentsSummary.ts
+++ b/src/pages/home/hooks/useStudentsSummary.ts
@@ -1,12 +1,33 @@
 import { useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { getStudents } from '@/shared/api/students';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { getStudents, type GetStudentsResponse } from '@/shared/api/students';
 
 export const useStudentsSummary = () => {
-  const { data, isLoading, refetch } = useQuery({
+  const queryClient = useQueryClient();
+  const studentsCache = queryClient.getQueryData<GetStudentsResponse>([
+    'students',
+    { page: 1, size: 20 },
+  ]);
+  const studentsCacheUpdatedAt = queryClient.getQueryState([
+    'students',
+    { page: 1, size: 20 },
+  ])?.dataUpdatedAt;
+  const hasEnoughCache = (studentsCache?.students.length ?? 0) >= 3;
+  const initialData = hasEnoughCache
+    ? {
+        ...studentsCache,
+        size: 3,
+        students: studentsCache?.students.slice(0, 3) ?? [],
+      }
+    : undefined;
+
+  const { data, isLoading, refetch } = useQuery<GetStudentsResponse>({
     queryKey: ['home', 'students', 1, 3],
     queryFn: () => getStudents({ page: 1, size: 3 }),
     staleTime: 1000 * 60 * 5,
+    enabled: !hasEnoughCache,
+    initialData,
+    initialDataUpdatedAt: initialData ? studentsCacheUpdatedAt : undefined,
   });
 
   return useMemo(

--- a/src/pages/home/hooks/useStudentsSummary.ts
+++ b/src/pages/home/hooks/useStudentsSummary.ts
@@ -1,31 +1,11 @@
 import { useMemo } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { getStudents } from '@/shared/api/students';
-import type { GetStudentsResponse } from '@/shared/api/students';
 
 export const useStudentsSummary = () => {
-  const queryClient = useQueryClient();
-  const studentListCache = queryClient.getQueryData<GetStudentsResponse>([
-    'students',
-    { page: 1, size: 20 },
-  ]);
-  const studentListUpdatedAt = queryClient.getQueryState([
-    'students',
-    { page: 1, size: 20 },
-  ])?.dataUpdatedAt;
-
   const { data, isLoading, refetch } = useQuery({
     queryKey: ['home', 'students', 1, 3],
     queryFn: () => getStudents({ page: 1, size: 3 }),
-    initialData: studentListCache
-      ? {
-          ...studentListCache,
-          page: 1,
-          size: 3,
-          students: studentListCache.students.slice(0, 3),
-        }
-      : undefined,
-    initialDataUpdatedAt: studentListCache ? studentListUpdatedAt : undefined,
     staleTime: 1000 * 60 * 5,
   });
 

--- a/src/pages/student/index.tsx
+++ b/src/pages/student/index.tsx
@@ -7,8 +7,7 @@ import ModalOpenButton from '@/shared/modal/ModalOpenButton';
 import { getAgeGroupLabel } from '@/utils/student/getAgeGroupLabel';
 import InvoiceListModal from './components/InvoiceListModal';
 import Chip from '@/shared/chip/Chip';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import type { GetStudentsResponse } from '@/shared/api/students';
+import { useQuery } from '@tanstack/react-query';
 
 const getAgeGroupTone = (ageGroup: Student['age_group'] | null) => {
   const normalized = ageGroup ? String(ageGroup).toUpperCase() : '';
@@ -32,27 +31,9 @@ const getAgeGroupTone = (ageGroup: Student['age_group'] | null) => {
 function StudentPage() {
   // 학생 모달 상태 관리
   const { isOpen, openCreate, openDetail } = useStudentModalStore();
-  const queryClient = useQueryClient();
-  const homeCache = queryClient.getQueryData<GetStudentsResponse>([
-    'home',
-    'students',
-    1,
-    3,
-  ]);
-  const homeCacheUpdatedAt = queryClient.getQueryState([
-    'home',
-    'students',
-    1,
-    3,
-  ])?.dataUpdatedAt;
-
   const { data, isFetching, refetch } = useQuery({
     queryKey: ['students', { page: 1, size: 20 }],
     queryFn: () => getStudents({ page: 1, size: 20 }),
-    initialData: homeCache
-      ? { ...homeCache, page: 1, size: 20 }
-      : undefined,
-    initialDataUpdatedAt: homeCache ? homeCacheUpdatedAt : undefined,
     staleTime: 1000 * 60 * 5,
     refetchOnMount: (query) => query.isStale(),
   });

--- a/src/shared/api/students/index.ts
+++ b/src/shared/api/students/index.ts
@@ -32,7 +32,11 @@ export const getStudents = async ({
     const students = Array.isArray(res.data.students) ? res.data.students : [];
 
     return {
-      total_count: Number(res.headers['x-total-count'] ?? students.length),
+      total_count: Number(
+        res.data.total_count ??
+          res.headers['x-total-count'] ??
+          students.length,
+      ),
       page,
       size,
       students,

--- a/src/store/message/messageTemplateStore.ts
+++ b/src/store/message/messageTemplateStore.ts
@@ -17,6 +17,7 @@ interface MessageTemplateForm {
 
 interface MessageTemplateStore {
   templates: MessageTemplate[];
+  totalCount: number;
   selectedTemplateId: number | null;
   mode: TemplateMode;
   form: MessageTemplateForm;
@@ -49,6 +50,7 @@ const getEmptyForm = (): MessageTemplateForm => ({
 export const useMessageTemplateStore = create<MessageTemplateStore>(
   (set, get) => ({
     templates: [],
+    totalCount: 0,
     selectedTemplateId: null,
     mode: 'CREATE',
     form: getEmptyForm(),
@@ -64,9 +66,10 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
       if (!force && (hasLoadedTemplates || isLoadingTemplates)) return;
 
       set({ isLoadingTemplates: true });
-      const { templates } = await getMessageTemplates({ page, size });
+      const { templates, total_count } = await getMessageTemplates({ page, size });
       set({
         templates,
+        totalCount: total_count,
         selectedTemplateId: null,
         mode: 'CREATE',
         form: getEmptyForm(),
@@ -119,7 +122,7 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
       }),
 
     addTemplate: async () => {
-      const { form, templates } = get();
+      const { form, templates, totalCount } = get();
       const title = form.title.trim();
       const content = form.content.trim();
 
@@ -136,6 +139,7 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
         const nextTemplates = [createdTemplate, ...templates];
         set({
           templates: nextTemplates,
+          totalCount: totalCount + 1,
           selectedTemplateId: createdTemplate.id,
           mode: 'UPDATE',
           form: {
@@ -177,12 +181,14 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
     },
 
     deleteTemplate: (id) => {
-      const { templates, selectedTemplateId } = get();
+      const { templates, selectedTemplateId, totalCount } = get();
       const nextTemplates = templates.filter((template) => template.id !== id);
+      const nextTotalCount = Math.max(0, totalCount - 1);
 
       if (!nextTemplates.length) {
         set({
           templates: [],
+          totalCount: nextTotalCount,
           selectedTemplateId: null,
           mode: 'CREATE',
           form: getEmptyForm(),
@@ -194,6 +200,7 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
       if (selectedTemplateId === id) {
         set({
           templates: nextTemplates,
+          totalCount: nextTotalCount,
           selectedTemplateId: null,
           mode: 'CREATE',
           form: getEmptyForm(),
@@ -204,6 +211,7 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
 
       set({
         templates: nextTemplates,
+        totalCount: nextTotalCount,
         menuOpenId: null,
       });
     },


### PR DESCRIPTION
**요약**
- 대시보드 캐시 분리와 재사용을 보완해 중복 호출을 줄였습니다.
- 수강 관리 모바일 카드 레이아웃과 학생 수 집계 표시를 개선했습니다.

**주요 변경사항**
- 학생/수강 캐시 키 분리 및 요약 데이터 재사용 로직 정리
- 수강 관리 모바일 카드형 리스트 추가 및 데스크톱 테이블 유지
- 학생 총 인원 표기를 API `total_count` 기준으로 반영

**테스트/확인 포인트**
- 학생/수강 페이지에서 목록 호출 후 대시보드 이동 시 추가 호출이 줄어드는지 확인
- 대시보드 단독 진입 시 요약 데이터가 정상 호출되는지 확인
- 수강 관리 모바일 화면에서 카드 레이아웃이 깨짐 없이 노출되는지 확인
- 테스트 실행하지 않음