### PR TITLE
홈 요약 캐시 초기 데이터 안정화 및 코스 API 타입 재export, 템플릿 캐시 신선도 정합성 개선

### DIFF
--- a/src/pages/home/hooks/useCoursesSummary.ts
+++ b/src/pages/home/hooks/useCoursesSummary.ts
@@ -13,13 +13,14 @@ export const useCoursesSummary = () => {
     { page: 1, size: 20 },
   ])?.dataUpdatedAt;
   const hasEnoughCache = (coursesCache?.courses.length ?? 0) >= 3;
-  const initialData = hasEnoughCache
-    ? {
-        ...coursesCache,
-        size: 3,
-        courses: coursesCache?.courses.slice(0, 3) ?? [],
-      }
-    : undefined;
+  const initialData =
+    hasEnoughCache && coursesCache
+      ? {
+          ...coursesCache,
+          size: 3,
+          courses: coursesCache.courses.slice(0, 3),
+        }
+      : undefined;
 
   const { data, isLoading, refetch } = useQuery<GetCoursesResponse>({
     queryKey: ['home', 'courses', 1, 3],

--- a/src/pages/home/hooks/useMessageTemplatesSummary.ts
+++ b/src/pages/home/hooks/useMessageTemplatesSummary.ts
@@ -6,6 +6,9 @@ import { useMessageTemplateStore } from '@/store/message/messageTemplateStore';
 export const useMessageTemplatesSummary = () => {
   const templatesCache = useMessageTemplateStore((state) => state.templates);
   const totalCountCache = useMessageTemplateStore((state) => state.totalCount);
+  const templatesUpdatedAt = useMessageTemplateStore(
+    (state) => state.templatesUpdatedAt,
+  );
   const hasEnoughCache = templatesCache.length >= 3 && totalCountCache > 0;
   const initialData: GetMessageTemplatesResponse | undefined = hasEnoughCache
     ? {
@@ -21,6 +24,7 @@ export const useMessageTemplatesSummary = () => {
     queryFn: () => getMessageTemplates({ page: 1, size: 3 }),
     enabled: !hasEnoughCache,
     initialData,
+    initialDataUpdatedAt: initialData ? templatesUpdatedAt ?? undefined : undefined,
   });
 
   return useMemo(

--- a/src/pages/home/hooks/useStudentsSummary.ts
+++ b/src/pages/home/hooks/useStudentsSummary.ts
@@ -13,13 +13,14 @@ export const useStudentsSummary = () => {
     { page: 1, size: 20 },
   ])?.dataUpdatedAt;
   const hasEnoughCache = (studentsCache?.students.length ?? 0) >= 3;
-  const initialData = hasEnoughCache
-    ? {
-        ...studentsCache,
-        size: 3,
-        students: studentsCache?.students.slice(0, 3) ?? [],
-      }
-    : undefined;
+  const initialData =
+    hasEnoughCache && studentsCache
+      ? {
+          ...studentsCache,
+          size: 3,
+          students: studentsCache.students.slice(0, 3),
+        }
+      : undefined;
 
   const { data, isLoading, refetch } = useQuery<GetStudentsResponse>({
     queryKey: ['home', 'students', 1, 3],

--- a/src/shared/api/courses/index.ts
+++ b/src/shared/api/courses/index.ts
@@ -8,6 +8,13 @@ import type {
   GetCoursesResponse,
 } from './courses.types';
 
+export type {
+  CreateCoursePayload,
+  GetCoursesApiResponse,
+  GetCoursesProps,
+  GetCoursesResponse,
+} from './courses.types';
+
 // ====================
 // GET : 모든 수강 정보 불러오기
 // ====================

--- a/src/store/message/messageTemplateStore.ts
+++ b/src/store/message/messageTemplateStore.ts
@@ -24,6 +24,7 @@ interface MessageTemplateStore {
   menuOpenId: number | null;
   isLoadingTemplates: boolean;
   hasLoadedTemplates: boolean;
+  templatesUpdatedAt: number | null;
   fetchTemplates: (options?: { page?: number; size?: number; force?: boolean }) => Promise<void>;
   selectTemplate: (id: number) => void;
   setFormField: (field: FormField, value: MessageTemplateForm[FormField]) => void;
@@ -57,6 +58,7 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
     menuOpenId: null,
     isLoadingTemplates: false,
     hasLoadedTemplates: false,
+    templatesUpdatedAt: null,
 
     fetchTemplates: async (options) => {
       const { hasLoadedTemplates, isLoadingTemplates } = get();
@@ -76,6 +78,7 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
         menuOpenId: null,
         isLoadingTemplates: false,
         hasLoadedTemplates: true,
+        templatesUpdatedAt: Date.now(),
       });
     },
 
@@ -147,6 +150,7 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
             title: createdTemplate.title,
             content: createdTemplate.content,
           },
+          templatesUpdatedAt: Date.now(),
         });
       } catch (error) {
         console.error('Failed to create message template:', error);
@@ -177,6 +181,7 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
 
       set({
         templates: nextTemplates,
+        templatesUpdatedAt: Date.now(),
       });
     },
 
@@ -193,6 +198,7 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
           mode: 'CREATE',
           form: getEmptyForm(),
           menuOpenId: null,
+          templatesUpdatedAt: Date.now(),
         });
         return;
       }
@@ -205,6 +211,7 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
           mode: 'CREATE',
           form: getEmptyForm(),
           menuOpenId: null,
+          templatesUpdatedAt: Date.now(),
         });
         return;
       }
@@ -213,6 +220,7 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
         templates: nextTemplates,
         totalCount: nextTotalCount,
         menuOpenId: null,
+        templatesUpdatedAt: Date.now(),
       });
     },
   }),


### PR DESCRIPTION
**요약**
- 홈 요약 훅의 캐시 초기 데이터 처리를 안전하게 정리하고, 코스 API 타입 재export로 import 오류를 해소했습니다.
- 메시지 템플릿 스토어에 업데이트 타임스탬프를 추가해 요약 훅의 캐시 신선도 판단을 일관되게 맞췄습니다.

**주요 변경사항**
- 코스 API에서 응답 타입 재export 추가
- 코스/학생 요약 훅의 initialData 생성 조건 강화
- 메시지 템플릿 스토어에 마지막 갱신 시각 저장 필드 추가
- 메시지 템플릿 CRUD 동작 시 갱신 시각 업데이트
- 메시지 템플릿 요약 훅에 initialDataUpdatedAt 전달

**테스트/확인 포인트**
- 테스트 실행하지 않음
- 홈 화면 요약 섹션에서 코스/학생 데이터가 정상 표시되는지 확인
- 메시지 템플릿 목록 변경 후 홈 요약의 캐시 갱신 타이밍이 일관되는지 확인