### PR TITLE
feat: 학생/청구서/템플릿 수정 API 연동 정리 및 응답 정규화 안정성 개선

### DIFF
--- a/src/pages/message/template/hooks/useTemplateForm.ts
+++ b/src/pages/message/template/hooks/useTemplateForm.ts
@@ -19,12 +19,12 @@ export const useTemplateForm = () => {
   );
 
   // 모드에 따라 생성/수정 제출을 처리
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (mode === 'CREATE') {
-      addTemplate();
+      await addTemplate();
       return;
     }
-    updateTemplate();
+    await updateTemplate();
   };
 
   const canSubmit = canSubmitTemplateForm(form);

--- a/src/pages/student/components/InvoiceListModal/components/InvoiceListModalBody.tsx
+++ b/src/pages/student/components/InvoiceListModal/components/InvoiceListModalBody.tsx
@@ -13,6 +13,7 @@ interface InvoiceListModalBodyProps {
     status: InvoiceStatus;
     method: PaymentMethod;
     paid_at: string | null;
+    updated_at?: string;
   }) => void;
   onSendMessage?: (invoice: InvoiceData) => void;
 }

--- a/src/pages/student/components/InvoiceListModal/components/invoiceCard/hooks/useInvoiceCard.ts
+++ b/src/pages/student/components/InvoiceListModal/components/invoiceCard/hooks/useInvoiceCard.ts
@@ -9,6 +9,7 @@ import { useToastStore } from '@/store/feedback/toastStore';
 import type { InvoiceData } from '../types';
 import { formatDateLabel, fromDateOnly, toDateOnly } from '../utils/date';
 import { classTypeLabel, methodLabel, statusLabel } from '../utils/labels';
+import { isAxiosError } from 'axios';
 
 // 청구서 카드에서 사용되는 데이터와 로직을 관리하는 커스텀 훅
 interface UseInvoiceCardResult {
@@ -44,6 +45,7 @@ export default function useInvoiceCard(
     status: InvoiceStatus;
     method: PaymentMethod;
     paid_at: string | null;
+    updated_at?: string;
   }) => void,
 ): UseInvoiceCardResult {
   const [isEdit, setIsEdit] = useState(false);
@@ -87,19 +89,24 @@ export default function useInvoiceCard(
 
     try {
       setLoading(true);
-      await patchInvoice(invoice.invoiceId, payload);
+      const patched = await patchInvoice(invoice.invoiceId, payload);
 
       onPatched({
-        invoice_id: invoice.invoiceId,
-        status: payload.status,
-        method: payload.method,
-        paid_at: payload.paid_at,
+        invoice_id: patched.invoice_id,
+        status: patched.status,
+        method: patched.method,
+        paid_at: patched.paid_at,
+        updated_at: patched.updated_at,
       });
 
       addToast('success', '청구서가 수정되었습니다.');
       setIsEdit(false);
     } catch (e) {
-      console.error(e);
+      if (isAxiosError(e)) {
+        console.error('Invoice patch failed:', e.response?.status, e.response?.data);
+      } else {
+        console.error(e);
+      }
       alert('청구 정보 수정에 실패했습니다.');
     } finally {
       setLoading(false);

--- a/src/pages/student/components/InvoiceListModal/components/invoiceCard/types.ts
+++ b/src/pages/student/components/InvoiceListModal/components/invoiceCard/types.ts
@@ -23,6 +23,7 @@ export interface InvoiceCardProps {
     status: InvoiceStatus;
     method: PaymentMethod;
     paid_at: string | null;
+    updated_at?: string;
   }) => void;
   onSendMessage?: (invoice: InvoiceData) => void;
 }

--- a/src/pages/student/components/InvoiceListModal/index.tsx
+++ b/src/pages/student/components/InvoiceListModal/index.tsx
@@ -50,6 +50,7 @@ export default function InvoiceListModal() {
     status: InvoiceStatus;
     method: PaymentMethod;
     paid_at: string | null;
+    updated_at?: string;
   }) => {
     setInvociesList((prev) =>
       prev.map((p) =>
@@ -59,6 +60,7 @@ export default function InvoiceListModal() {
               status: next.status,
               method: next.method,
               paid_at: next.paid_at,
+              updated_at: next.updated_at ?? p.updated_at,
             }
           : p,
       ),

--- a/src/shared/api/invoices/index.ts
+++ b/src/shared/api/invoices/index.ts
@@ -1,8 +1,46 @@
 import { api } from '@/shared/api/axios';
 import type {
   PatchInvoicePayload,
+  PatchInvoiceResponse,
   StudentInvoiceResponse,
 } from '@/types/invoice';
+
+type PatchInvoiceApiResponse = {
+  invoice_id?: number;
+  invoiceId?: number;
+  enrollment_id?: number;
+  enrollmentId?: number;
+  student_id?: number;
+  studentId?: number;
+  status?: string;
+  method?: string | null;
+  paid_at?: string | null;
+  paidAt?: string | null;
+  updated_at?: string;
+  updatedAt?: string;
+};
+
+const normalizeInvoiceStatus = (status?: string) =>
+  String(status ?? '')
+    .toUpperCase()
+    .trim() as PatchInvoiceResponse['status'];
+
+const normalizePaymentMethod = (method?: string | null) => {
+  if (!method) return null;
+  return String(method).toUpperCase().trim() as PatchInvoiceResponse['method'];
+};
+
+const normalizePatchInvoiceResponse = (
+  data: PatchInvoiceApiResponse,
+): PatchInvoiceResponse => ({
+  invoice_id: Number(data.invoice_id ?? data.invoiceId ?? 0),
+  enrollment_id: data.enrollment_id ?? data.enrollmentId,
+  student_id: data.student_id ?? data.studentId,
+  status: normalizeInvoiceStatus(data.status),
+  method: normalizePaymentMethod(data.method),
+  paid_at: data.paid_at ?? data.paidAt ?? null,
+  updated_at: data.updated_at ?? data.updatedAt ?? '',
+});
 
 // ====================
 // GET : 학생 1명 청구서 목록
@@ -33,7 +71,7 @@ export const getStudentInvoices = async (
 export const patchInvoice = async (
   invoiceId: number,
   payload: PatchInvoicePayload,
-) => {
+): Promise<PatchInvoiceResponse> => {
   // 서버(명세) validation을 프론트에서도 1차로 막아줌
   if (payload.status === 'PAID') {
     if (!payload.method) throw new Error('method is required when paid');
@@ -44,8 +82,6 @@ export const patchInvoice = async (
     payload.status === 'UNPAID'
       ? {
           status: 'UNPAID',
-          method: null,
-          paid_at: null,
         }
       : {
           status: 'PAID',
@@ -53,7 +89,10 @@ export const patchInvoice = async (
           paid_at: payload.paid_at,
         };
 
-  const res = await api.patch(`/invoices/${invoiceId}`, body);
+  const res = await api.patch<PatchInvoiceApiResponse>(
+    `/invoices/${invoiceId}`,
+    body,
+  );
 
-  return res.data;
+  return normalizePatchInvoiceResponse(res.data);
 };

--- a/src/shared/api/invoices/index.ts
+++ b/src/shared/api/invoices/index.ts
@@ -32,15 +32,22 @@ const normalizePaymentMethod = (method?: string | null) => {
 
 const normalizePatchInvoiceResponse = (
   data: PatchInvoiceApiResponse,
-): PatchInvoiceResponse => ({
-  invoice_id: Number(data.invoice_id ?? data.invoiceId ?? 0),
-  enrollment_id: data.enrollment_id ?? data.enrollmentId,
-  student_id: data.student_id ?? data.studentId,
-  status: normalizeInvoiceStatus(data.status),
-  method: normalizePaymentMethod(data.method),
-  paid_at: data.paid_at ?? data.paidAt ?? null,
-  updated_at: data.updated_at ?? data.updatedAt ?? '',
-});
+): PatchInvoiceResponse => {
+  const invoiceId = data.invoice_id ?? data.invoiceId;
+  if (invoiceId == null) {
+    throw new Error('Invoice ID is missing in the API response.');
+  }
+
+  return {
+    invoice_id: Number(invoiceId),
+    enrollment_id: data.enrollment_id ?? data.enrollmentId,
+    student_id: data.student_id ?? data.studentId,
+    status: normalizeInvoiceStatus(data.status),
+    method: normalizePaymentMethod(data.method),
+    paid_at: data.paid_at ?? data.paidAt ?? null,
+    updated_at: data.updated_at ?? data.updatedAt ?? '',
+  };
+};
 
 // ====================
 // GET : 학생 1명 청구서 목록

--- a/src/shared/api/message/index.ts
+++ b/src/shared/api/message/index.ts
@@ -42,14 +42,21 @@ const normalizeTemplateTypeToApi = (type: MessageTemplate['type']) =>
 
 const mapMessageTemplate = (
   template: MessageTemplateApiResponse,
-): MessageTemplate => ({
-  id: Number(template.template_id ?? template.templateId ?? 0),
-  type: normalizeTemplateTypeFromApi(template.type),
-  title: template.title,
-  content: template.content,
-  created_at: template.created_at ?? template.createdAt ?? '',
-  updated_at: template.updated_at ?? template.updatedAt ?? '',
-});
+): MessageTemplate => {
+  const templateId = template.template_id ?? template.templateId;
+  if (templateId == null) {
+    throw new Error('Template ID is missing in the API response.');
+  }
+
+  return {
+    id: Number(templateId),
+    type: normalizeTemplateTypeFromApi(template.type),
+    title: template.title,
+    content: template.content,
+    created_at: template.created_at ?? template.createdAt ?? '',
+    updated_at: template.updated_at ?? template.updatedAt ?? '',
+  };
+};
 
 const mapCreatedTemplate = (
   template: CreateMessageTemplateApiResponse,

--- a/src/shared/api/message/index.ts
+++ b/src/shared/api/message/index.ts
@@ -6,30 +6,56 @@ import type {
   GetMessageTemplatesApiResponse,
   GetMessageTemplatesProps,
   GetMessageTemplatesResponse,
-  MessageTemplateApiItem,
+  MessageTemplateApiResponse,
+  UpdateMessageTemplatePayload,
 } from './message.types';
 
 export type {
   CreateMessageTemplatePayload,
   GetMessageTemplatesProps,
   GetMessageTemplatesResponse,
-  MessageTemplateApiItem,
+  UpdateMessageTemplatePayload,
 } from './message.types';
 
-const mapMessageTemplate = (template: MessageTemplateApiItem): MessageTemplate => ({
-  id: template.template_id,
-  type: template.type,
+const TEMPLATE_TYPE_TO_API: Record<string, string> = {
+  ATTENDANCE: 'attended',
+  ABSENT: 'absent',
+  MAKEUP: 'makeup',
+};
+
+const TEMPLATE_TYPE_FROM_API: Record<string, MessageTemplate['type']> = {
+  attended: 'ATTENDANCE',
+  attendance: 'ATTENDANCE',
+  absent: 'ABSENT',
+  makeup: 'MAKEUP',
+};
+
+const normalizeTemplateTypeFromApi = (type: string): MessageTemplate['type'] => {
+  const normalized = String(type).trim().toLowerCase();
+  const mapped = TEMPLATE_TYPE_FROM_API[normalized];
+  if (mapped) return mapped;
+  return String(type).trim().toUpperCase() as MessageTemplate['type'];
+};
+
+const normalizeTemplateTypeToApi = (type: MessageTemplate['type']) =>
+  TEMPLATE_TYPE_TO_API[type] ?? String(type).toLowerCase();
+
+const mapMessageTemplate = (
+  template: MessageTemplateApiResponse,
+): MessageTemplate => ({
+  id: Number(template.template_id ?? template.templateId ?? 0),
+  type: normalizeTemplateTypeFromApi(template.type),
   title: template.title,
   content: template.content,
-  created_at: template.created_at,
-  updated_at: template.updated_at,
+  created_at: template.created_at ?? template.createdAt ?? '',
+  updated_at: template.updated_at ?? template.updatedAt ?? '',
 });
 
 const mapCreatedTemplate = (
   template: CreateMessageTemplateApiResponse,
 ): MessageTemplate => ({
   id: template.templateId,
-  type: template.type,
+  type: normalizeTemplateTypeFromApi(template.type),
   title: template.title,
   content: template.content,
   created_at: template.createdAt,
@@ -80,7 +106,41 @@ export const createMessageTemplate = async (
 ): Promise<MessageTemplate> => {
   const res = await api.post<CreateMessageTemplateApiResponse>(
     '/messages/templates',
-    payload,
+    {
+      ...payload,
+      type: normalizeTemplateTypeToApi(payload.type),
+    },
   );
   return mapCreatedTemplate(res.data);
+};
+
+// ====================
+// PATCH : 메시지 템플릿 수정
+// ====================
+export const updateMessageTemplate = async (
+  templateId: number,
+  payload: UpdateMessageTemplatePayload,
+): Promise<MessageTemplate> => {
+  const body: Record<string, string> = {};
+
+  if (payload.type) {
+    body.type = normalizeTemplateTypeToApi(payload.type);
+  }
+  if (payload.title !== undefined) {
+    body.title = payload.title;
+  }
+  if (payload.content !== undefined) {
+    body.content = payload.content;
+  }
+
+  if (Object.keys(body).length === 0) {
+    throw new Error('At least one field must be provided');
+  }
+
+  const res = await api.patch<MessageTemplateApiResponse>(
+    `/messages/templates/${templateId}`,
+    body,
+  );
+
+  return mapMessageTemplate(res.data);
 };

--- a/src/shared/api/message/message.types.ts
+++ b/src/shared/api/message/message.types.ts
@@ -10,6 +10,18 @@ export interface MessageTemplateApiItem {
   updated_at: string;
 }
 
+export interface MessageTemplateApiResponse {
+  template_id?: number;
+  templateId?: number;
+  type: string;
+  title: string;
+  content: string;
+  created_at?: string;
+  createdAt?: string;
+  updated_at?: string;
+  updatedAt?: string;
+}
+
 export interface CreateMessageTemplatePayload {
   type: MessageTemplateType;
   title: string;
@@ -18,18 +30,24 @@ export interface CreateMessageTemplatePayload {
 
 export interface CreateMessageTemplateApiResponse {
   templateId: number;
-  type: MessageTemplateType;
+  type: string;
   title: string;
   content: string;
   createdAt: string;
   updatedAt: string;
 }
 
+export interface UpdateMessageTemplatePayload {
+  type?: MessageTemplateType;
+  title?: string;
+  content?: string;
+}
+
 export interface GetMessageTemplatesApiResponse {
   total_count: number;
   page: number;
   size: number;
-  templates: MessageTemplateApiItem[];
+  templates: MessageTemplateApiResponse[];
 }
 
 export interface GetMessageTemplatesProps {

--- a/src/shared/api/message/message.types.ts
+++ b/src/shared/api/message/message.types.ts
@@ -1,15 +1,6 @@
 import type { MessageTemplate } from '@/types/messageTemplate';
 import type { MessageTemplateType } from '@/constants/messageTemplate';
 
-export interface MessageTemplateApiItem {
-  template_id: number;
-  type: MessageTemplateType;
-  title: string;
-  content: string;
-  created_at: string;
-  updated_at: string;
-}
-
 export interface MessageTemplateApiResponse {
   template_id?: number;
   templateId?: number;

--- a/src/shared/api/students/index.ts
+++ b/src/shared/api/students/index.ts
@@ -36,17 +36,24 @@ interface StudentApiResponse {
   updatedAt?: string;
 }
 
-const normalizeStudentResponse = (student: StudentApiResponse): Student => ({
-  student_id: Number(student.student_id ?? student.studentId ?? 0),
-  name: student.name,
-  age_group: (student.age_group ?? student.ageGroup ?? 'adult') as Student['age_group'],
-  phone: student.phone ?? '',
-  parent_phone: student.parent_phone ?? student.parentPhone ?? '',
-  memo: student.memo ?? null,
-  family_discount: Boolean(student.family_discount ?? student.familyDiscount),
-  created_at: student.created_at ?? student.createdAt ?? '',
-  updated_at: student.updated_at ?? student.updatedAt ?? '',
-});
+const normalizeStudentResponse = (student: StudentApiResponse): Student => {
+  const studentId = student.student_id ?? student.studentId;
+  if (studentId == null) {
+    throw new Error('Student ID is missing in the API response.');
+  }
+
+  return {
+    student_id: Number(studentId),
+    name: student.name,
+    age_group: (student.age_group ?? student.ageGroup ?? 'adult') as Student['age_group'],
+    phone: student.phone ?? '',
+    parent_phone: student.parent_phone ?? student.parentPhone ?? '',
+    memo: student.memo ?? null,
+    family_discount: Boolean(student.family_discount ?? student.familyDiscount),
+    created_at: student.created_at ?? student.createdAt ?? '',
+    updated_at: student.updated_at ?? student.updatedAt ?? '',
+  };
+};
 
 const normalizeAgeGroupForRequest = (ageGroup: Student['age_group']) =>
   String(ageGroup).toLowerCase() as Student['age_group'];

--- a/src/shared/api/students/index.ts
+++ b/src/shared/api/students/index.ts
@@ -18,6 +18,39 @@ export type {
   UpdateStudentPayload,
 } from './students.types';
 
+interface StudentApiResponse {
+  student_id?: number;
+  studentId?: number;
+  name: string;
+  age_group?: Student['age_group'];
+  ageGroup?: Student['age_group'];
+  phone?: string | null;
+  parent_phone?: string | null;
+  parentPhone?: string | null;
+  memo?: string | null;
+  family_discount?: boolean;
+  familyDiscount?: boolean;
+  created_at?: string;
+  createdAt?: string;
+  updated_at?: string;
+  updatedAt?: string;
+}
+
+const normalizeStudentResponse = (student: StudentApiResponse): Student => ({
+  student_id: Number(student.student_id ?? student.studentId ?? 0),
+  name: student.name,
+  age_group: (student.age_group ?? student.ageGroup ?? 'adult') as Student['age_group'],
+  phone: student.phone ?? '',
+  parent_phone: student.parent_phone ?? student.parentPhone ?? '',
+  memo: student.memo ?? null,
+  family_discount: Boolean(student.family_discount ?? student.familyDiscount),
+  created_at: student.created_at ?? student.createdAt ?? '',
+  updated_at: student.updated_at ?? student.updatedAt ?? '',
+});
+
+const normalizeAgeGroupForRequest = (ageGroup: Student['age_group']) =>
+  String(ageGroup).toLowerCase() as Student['age_group'];
+
 // ====================
 // GET : 모든 학생 정보 불러오기
 // ====================
@@ -76,18 +109,21 @@ export const createStudent = async (payload: CreateStudentPayload) => {
 };
 
 // ====================
-// PATCH : 학생 정보 수정 (json-server 권장)
+// PATCH : 학생 정보 수정
 // ====================
 export const updateStudent = async (
   studentId: number,
   payload: UpdateStudentPayload,
 ) => {
-  const res = await api.put(`/students/${studentId}`, {
-    ...payload,
-    updated_at: new Date().toISOString(),
+  const { family_discount, ...rest } = payload;
+  const res = await api.patch<StudentApiResponse>(`/students/${studentId}`, {
+    ...rest,
+    age_group: normalizeAgeGroupForRequest(rest.age_group),
+    family_discount,
+    familyDiscount: family_discount,
   });
 
-  return res.data;
+  return normalizeStudentResponse(res.data);
 };
 
 // ====================

--- a/src/shared/api/students/students.types.ts
+++ b/src/shared/api/students/students.types.ts
@@ -32,7 +32,7 @@ export interface CreateStudentPayload {
 }
 
 // ====================
-// PATCH : 학생 정보 수정 (json-server 권장)
+// PATCH : 학생 정보 수정
 // ====================
 export interface UpdateStudentPayload {
   name: string;

--- a/src/store/message/messageTemplateStore.ts
+++ b/src/store/message/messageTemplateStore.ts
@@ -2,7 +2,11 @@ import {
   DEFAULT_MESSAGE_TEMPLATE_TYPE,
   type MessageTemplateType,
 } from '@/constants/messageTemplate';
-import { createMessageTemplate, getMessageTemplates } from '@/shared/api/message';
+import {
+  createMessageTemplate,
+  getMessageTemplates,
+  updateMessageTemplate,
+} from '@/shared/api/message';
 import type { MessageTemplate } from '@/types/messageTemplate';
 import { create } from 'zustand';
 
@@ -32,15 +36,12 @@ interface MessageTemplateStore {
   toggleMenu: (id: number) => void;
   closeMenu: () => void;
   addTemplate: () => Promise<void>;
-  updateTemplate: () => void;
+  updateTemplate: () => Promise<void>;
   deleteTemplate: (id: number) => void;
 }
 
 const DEFAULT_PAGE = 1;
 const DEFAULT_SIZE = 10;
-
-const getNowString = () =>
-  new Date().toISOString().slice(0, 19).replace('T', ' ');
 
 const getEmptyForm = (): MessageTemplateForm => ({
   type: DEFAULT_MESSAGE_TEMPLATE_TYPE,
@@ -157,7 +158,7 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
       }
     },
 
-    updateTemplate: () => {
+    updateTemplate: async () => {
       const { selectedTemplateId, form, templates } = get();
       if (!selectedTemplateId) return;
 
@@ -166,23 +167,42 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
       const type = form.type;
       if (!title || !content) return;
 
-      const now = getNowString();
-      const nextTemplates = templates.map((template) =>
-        template.id === selectedTemplateId
-          ? {
-              ...template,
-              type,
-              title,
-              content,
-              updated_at: now,
-            }
-          : template,
+      const selectedTemplate = templates.find(
+        (template) => template.id === selectedTemplateId,
       );
+      if (!selectedTemplate) return;
 
-      set({
-        templates: nextTemplates,
-        templatesUpdatedAt: Date.now(),
-      });
+      const payload: {
+        type?: MessageTemplateType;
+        title?: string;
+        content?: string;
+      } = {};
+      if (selectedTemplate.type !== type) payload.type = type;
+      if (selectedTemplate.title !== title) payload.title = title;
+      if (selectedTemplate.content !== content) payload.content = content;
+      if (Object.keys(payload).length === 0) return;
+
+      try {
+        const updatedTemplate = await updateMessageTemplate(
+          selectedTemplateId,
+          payload,
+        );
+        const nextTemplates = templates.map((template) =>
+          template.id === selectedTemplateId ? updatedTemplate : template,
+        );
+
+        set({
+          templates: nextTemplates,
+          form: {
+            type: updatedTemplate.type ?? DEFAULT_MESSAGE_TEMPLATE_TYPE,
+            title: updatedTemplate.title,
+            content: updatedTemplate.content,
+          },
+          templatesUpdatedAt: Date.now(),
+        });
+      } catch (error) {
+        console.error('Failed to update message template:', error);
+      }
     },
 
     deleteTemplate: (id) => {

--- a/src/types/invoice.ts
+++ b/src/types/invoice.ts
@@ -8,6 +8,7 @@ export interface Invoice {
   enrollment_id: number;
   issued_at: string;
   paid_at: string | null;
+  updated_at?: string;
 
   status: InvoiceStatus;
   method: PaymentMethod;
@@ -29,4 +30,14 @@ export interface PatchInvoicePayload {
   status: InvoiceStatus;
   method: PaymentMethod;
   paid_at: string | null;
+}
+
+export interface PatchInvoiceResponse {
+  invoice_id: number;
+  enrollment_id?: number;
+  student_id?: number;
+  status: InvoiceStatus;
+  method: PaymentMethod;
+  paid_at: string | null;
+  updated_at: string;
 }


### PR DESCRIPTION
**요약**
- 학생/청구서/메시지 템플릿 수정 API 연동을 서버 스펙에 맞게 정리하고, 응답 정규화 로직의 안정성을 높였습니다.
- 코드리뷰 반영으로 필수 ID 누락 시 기본값으로 숨기지 않고 예외를 발생시키도록 개선했습니다.

**주요 변경사항**
- 메시지 템플릿 수정 흐름을 로컬 상태 갱신에서 실제 PATCH 호출 기반으로 변경했습니다.
- 메시지 템플릿 수정 시 변경된 필드만 전송하도록 payload를 분기하고, 타입/필드 케이스를 정규화했습니다.
- 청구서 PATCH 요청/응답 매핑을 정리하고, 수정 후 서버 응답값으로 화면 상태를 갱신하도록 변경했습니다.
- 청구서 미결제 전환 시 불필요한 필드 전송을 줄여 400 에러 가능성을 낮췄습니다.
- 학생 수정 API를 PATCH 스펙에 맞추고 요청/응답 필드 정규화를 추가했습니다.
- 학생 수정 시 가족할인 값 전달 보완(`family_discount`, `familyDiscount` 동시 전송) 로직을 반영했습니다.
- 코드리뷰 반영으로 `invoice_id`, `template_id`, `student_id` 누락 시 예외를 던지도록 수정했습니다.
- 사용되지 않는 메시지 템플릿 API 타입(`MessageTemplateApiItem`)을 제거했습니다.

**테스트/확인 포인트**
- 학생 상세 수정에서 이름/구분/연락처/가족할인 저장 후 값이 유지되는지 확인
- 청구서 수정에서 `PAID -> UNPAID`, `UNPAID -> PAID` 전환이 정상 저장되는지 확인
- 메시지 템플릿 수정에서 변경한 필드만 요청에 포함되는지(Network 탭) 확인
- 필수 ID가 누락된 비정상 응답에서 예외가 발생해 조용한 오염이 방지되는지 확인
- `npm run build` 통과 확인