### PR TITLE
공통 새로고침 버튼 도입 및 출결·이월·청구서 UX/동기화 개선

### DIFF
--- a/src/pages/course/index.tsx
+++ b/src/pages/course/index.tsx
@@ -10,6 +10,7 @@ import { formatToKoreanDate } from '@/utils/date/formatKoreanDate';
 import { getClassTypeLabel } from '@/utils/course/getClassTypeLabel';
 import { getCourses } from '@/shared/api/courses';
 import Chip from '@/shared/chip/Chip';
+import RefreshButton from '@/shared/button/RefreshButton';
 import { useQuery } from '@tanstack/react-query';
 
 const formatToHourMinute = (time?: string) => {
@@ -46,41 +47,11 @@ function CoursePage() {
   return (
     <div>
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <ModalOpenButton text="신규수업 추가" openModal={openCreate} />
-        <button
-          type="button"
-          onClick={() => refetch()}
-          disabled={isFetching}
-          className={`inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 ${
-            isFetching
-              ? 'border-gray-200 text-gray-400 cursor-not-allowed'
-              : 'border-primary text-primary hover:bg-primary/10 active:scale-95 active:bg-primary/20'
-          }`}
-        >
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 20 20"
-            fill="none"
-            aria-hidden="true"
-            className={isFetching ? 'animate-spin' : ''}
-          >
-            <path
-              d="M16 10a6 6 0 1 1-1.76-4.24"
-              stroke="currentColor"
-              strokeWidth="1.6"
-              strokeLinecap="round"
-            />
-            <path
-              d="M16 4v4h-4"
-              stroke="currentColor"
-              strokeWidth="1.6"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-          최신화
-        </button>
+        <ModalOpenButton text="신규수강 추가" openModal={openCreate} />
+        <RefreshButton
+          onRefresh={async () => refetch()}
+          isRefreshingExternal={isFetching}
+        />
       </div>
       {isEmpty ? (
         <div className="py-10 text-center text-gray-500">

--- a/src/pages/course/modal/CourseForm.tsx
+++ b/src/pages/course/modal/CourseForm.tsx
@@ -167,11 +167,38 @@ export default function CourseForm({
               ? 'CASH'
               : null
           : null;
+      const hasIsoTimezone = (value: string) =>
+        /([zZ]|[+-]\d{2}:\d{2})$/.test(value);
+      const formatTimezoneOffset = (date: Date) => {
+        const offsetMinutes = -date.getTimezoneOffset();
+        const sign = offsetMinutes >= 0 ? '+' : '-';
+        const absMinutes = Math.abs(offsetMinutes);
+        const hours = String(Math.floor(absMinutes / 60)).padStart(2, '0');
+        const minutes = String(absMinutes % 60).padStart(2, '0');
+        return `${sign}${hours}:${minutes}`;
+      };
+      const formatLocalIsoWithOffset = (value: string) => {
+        const parsed = new Date(value);
+        if (Number.isNaN(parsed.getTime())) return value;
+        const yyyy = parsed.getFullYear();
+        const mm = String(parsed.getMonth() + 1).padStart(2, '0');
+        const dd = String(parsed.getDate()).padStart(2, '0');
+        const hh = String(parsed.getHours()).padStart(2, '0');
+        const mi = String(parsed.getMinutes()).padStart(2, '0');
+        const ss = String(parsed.getSeconds()).padStart(2, '0');
+        return `${yyyy}-${mm}-${dd}T${hh}:${mi}:${ss}${formatTimezoneOffset(
+          parsed,
+        )}`;
+      };
       const invoicePaidAt: string | null =
         form.invoice.status === 'PAID'
-          ? form.invoice.paid_at.includes('T')
+          ? hasIsoTimezone(form.invoice.paid_at)
             ? form.invoice.paid_at
-            : `${formatDateOnly(form.invoice.paid_at)}T00:00:00`
+            : form.invoice.paid_at.includes('T')
+              ? formatLocalIsoWithOffset(form.invoice.paid_at)
+              : `${formatDateOnly(form.invoice.paid_at)}T00:00:00${formatTimezoneOffset(
+                  new Date(form.invoice.paid_at),
+                )}`
           : null;
 
       const payload = {

--- a/src/pages/course/modal/CourseForm.tsx
+++ b/src/pages/course/modal/CourseForm.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/constants/invoice';
 import { useToastStore } from '@/store/feedback/toastStore';
 import ConfirmModal from '@/shared/modal/ConfirmModal';
+import { toDateOnly, toInvoicePaidAt } from './courseFormDateUtils';
 
 interface CourseFormState {
   student: {
@@ -148,15 +149,6 @@ export default function CourseForm({
 
     setIsSubmitting(true);
     try {
-      const formatDateOnly = (value: string) => {
-        const parsed = new Date(value);
-        if (Number.isNaN(parsed.getTime())) return value;
-        const yyyy = parsed.getFullYear();
-        const mm = String(parsed.getMonth() + 1).padStart(2, '0');
-        const dd = String(parsed.getDate()).padStart(2, '0');
-        return `${yyyy}-${mm}-${dd}`;
-      };
-
       const invoiceStatus: 'PAID' | 'UNPAID' =
         form.invoice.status === 'PAID' ? 'PAID' : 'UNPAID';
       const invoiceMethod: 'CARD' | 'CASH' | null =
@@ -164,49 +156,20 @@ export default function CourseForm({
           ? form.invoice.method === 'CARD'
             ? 'CARD'
             : form.invoice.method === 'CASH'
-              ? 'CASH'
-              : null
+            ? 'CASH'
+            : null
           : null;
-      const hasIsoTimezone = (value: string) =>
-        /([zZ]|[+-]\d{2}:\d{2})$/.test(value);
-      const formatTimezoneOffset = (date: Date) => {
-        const offsetMinutes = -date.getTimezoneOffset();
-        const sign = offsetMinutes >= 0 ? '+' : '-';
-        const absMinutes = Math.abs(offsetMinutes);
-        const hours = String(Math.floor(absMinutes / 60)).padStart(2, '0');
-        const minutes = String(absMinutes % 60).padStart(2, '0');
-        return `${sign}${hours}:${minutes}`;
-      };
-      const formatLocalIsoWithOffset = (value: string) => {
-        const parsed = new Date(value);
-        if (Number.isNaN(parsed.getTime())) return value;
-        const yyyy = parsed.getFullYear();
-        const mm = String(parsed.getMonth() + 1).padStart(2, '0');
-        const dd = String(parsed.getDate()).padStart(2, '0');
-        const hh = String(parsed.getHours()).padStart(2, '0');
-        const mi = String(parsed.getMinutes()).padStart(2, '0');
-        const ss = String(parsed.getSeconds()).padStart(2, '0');
-        return `${yyyy}-${mm}-${dd}T${hh}:${mi}:${ss}${formatTimezoneOffset(
-          parsed,
-        )}`;
-      };
-      const invoicePaidAt: string | null =
-        form.invoice.status === 'PAID'
-          ? hasIsoTimezone(form.invoice.paid_at)
-            ? form.invoice.paid_at
-            : form.invoice.paid_at.includes('T')
-              ? formatLocalIsoWithOffset(form.invoice.paid_at)
-              : `${formatDateOnly(form.invoice.paid_at)}T00:00:00${formatTimezoneOffset(
-                  new Date(form.invoice.paid_at),
-                )}`
-          : null;
+      const invoicePaidAt = toInvoicePaidAt(
+        form.invoice.paid_at,
+        invoiceStatus,
+      );
 
       const payload = {
         student_id: form.student.student_id,
         class_type: form.class_type,
         family_discount: form.family_discount,
         lesson_count: form.lesson_count,
-        start_date: formatDateOnly(form.start_date),
+        start_date: toDateOnly(form.start_date),
         schedules: form.schedules,
         invoice: {
           status: invoiceStatus,

--- a/src/pages/course/modal/courseFormDateUtils.ts
+++ b/src/pages/course/modal/courseFormDateUtils.ts
@@ -1,0 +1,47 @@
+const hasIsoTimezone = (value: string) =>
+  /([zZ]|[+-]\d{2}:\d{2})$/.test(value);
+
+const formatTimezoneOffset = (date: Date) => {
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? '+' : '-';
+  const absMinutes = Math.abs(offsetMinutes);
+  const hours = String(Math.floor(absMinutes / 60)).padStart(2, '0');
+  const minutes = String(absMinutes % 60).padStart(2, '0');
+  return `${sign}${hours}:${minutes}`;
+};
+
+const formatDateOnly = (value: string) => {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  const yyyy = parsed.getFullYear();
+  const mm = String(parsed.getMonth() + 1).padStart(2, '0');
+  const dd = String(parsed.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+};
+
+const formatLocalIsoWithOffset = (value: string) => {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  const yyyy = parsed.getFullYear();
+  const mm = String(parsed.getMonth() + 1).padStart(2, '0');
+  const dd = String(parsed.getDate()).padStart(2, '0');
+  const hh = String(parsed.getHours()).padStart(2, '0');
+  const mi = String(parsed.getMinutes()).padStart(2, '0');
+  const ss = String(parsed.getSeconds()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}T${hh}:${mi}:${ss}${formatTimezoneOffset(
+    parsed,
+  )}`;
+};
+
+export const toInvoicePaidAt = (rawValue: string, status: 'PAID' | 'UNPAID') =>
+  status === 'PAID'
+    ? hasIsoTimezone(rawValue)
+      ? rawValue
+      : rawValue.includes('T')
+        ? formatLocalIsoWithOffset(rawValue)
+        : `${formatDateOnly(rawValue)}T00:00:00${formatTimezoneOffset(
+            new Date(rawValue),
+          )}`
+    : null;
+
+export const toDateOnly = formatDateOnly;

--- a/src/pages/home/components/DashboardHeader.tsx
+++ b/src/pages/home/components/DashboardHeader.tsx
@@ -1,14 +1,10 @@
+import RefreshButton from '@/shared/button/RefreshButton';
+
 interface DashboardHeaderProps {
-  cooldownSeconds: number;
-  isRefreshing: boolean;
-  onRefresh: () => void;
+  onRefresh: () => Promise<void>;
 }
 
-function DashboardHeader({
-  cooldownSeconds,
-  isRefreshing,
-  onRefresh,
-}: DashboardHeaderProps) {
+function DashboardHeader({ onRefresh }: DashboardHeaderProps) {
   return (
     <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div>
@@ -17,45 +13,7 @@ function DashboardHeader({
           오늘과 이번 달 주요 지표를 한눈에 확인하세요.
         </p>
       </div>
-      <button
-        type="button"
-        onClick={onRefresh}
-        disabled={isRefreshing || cooldownSeconds > 0}
-        className={`inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 ${
-          isRefreshing || cooldownSeconds > 0
-            ? 'border-gray-200 text-gray-400 cursor-not-allowed'
-            : 'border-primary text-primary hover:bg-primary/10 active:scale-95 active:bg-primary/20'
-        }`}
-      >
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 20 20"
-          fill="none"
-          aria-hidden="true"
-          className={isRefreshing ? 'animate-spin' : ''}
-        >
-          <path
-            d="M16 10a6 6 0 1 1-1.76-4.24"
-            stroke="currentColor"
-            strokeWidth="1.6"
-            strokeLinecap="round"
-          />
-          <path
-            d="M16 4v4h-4"
-            stroke="currentColor"
-            strokeWidth="1.6"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-        최신화
-        {cooldownSeconds > 0 && (
-          <span className="text-[11px] text-gray-400">
-            {cooldownSeconds}s
-          </span>
-        )}
-      </button>
+      <RefreshButton onRefresh={onRefresh} />
     </div>
   );
 }

--- a/src/pages/home/hooks/useRolloverLessons.ts
+++ b/src/pages/home/hooks/useRolloverLessons.ts
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getRollOverLessons } from '@/shared/api/lessons';
+import { rolloverLessonKeys } from '@/shared/queryKeys/rolloverLessons';
 
 export const useRolloverLessons = () => {
   const { data, isLoading, refetch } = useQuery({
-    queryKey: ['home', 'rollover-lessons'],
+    queryKey: rolloverLessonKeys.home(),
     queryFn: () => getRollOverLessons(),
   });
 

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -4,7 +4,6 @@ import { useRolloverLessons } from './hooks/useRolloverLessons';
 import { useCoursesSummary } from './hooks/useCoursesSummary';
 import { useStudentsSummary } from './hooks/useStudentsSummary';
 import { useMessageTemplatesSummary } from './hooks/useMessageTemplatesSummary';
-import { useEffect, useRef, useState } from 'react';
 import LessonSummaryCards from './components/sections/LessonSummaryCards';
 import LessonDistributionSection from './components/sections/LessonDistributionSection';
 import RolloverLessonSection from './components/sections/RolloverLessonSection';
@@ -18,36 +17,8 @@ function HomePage() {
   const coursesSummary = useCoursesSummary();
   const studentsSummary = useStudentsSummary();
   const templatesSummary = useMessageTemplatesSummary();
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const [cooldownSeconds, setCooldownSeconds] = useState(0);
-  const cooldownTimerRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    if (cooldownSeconds <= 0) {
-      if (cooldownTimerRef.current !== null) {
-        window.clearInterval(cooldownTimerRef.current);
-        cooldownTimerRef.current = null;
-      }
-      return;
-    }
-
-    if (cooldownTimerRef.current === null) {
-      cooldownTimerRef.current = window.setInterval(() => {
-        setCooldownSeconds((prev) => Math.max(0, prev - 1));
-      }, 1000);
-    }
-
-    return () => {
-      if (cooldownTimerRef.current !== null) {
-        window.clearInterval(cooldownTimerRef.current);
-        cooldownTimerRef.current = null;
-      }
-    };
-  }, [cooldownSeconds]);
 
   const handleRefresh = async () => {
-    if (isRefreshing || cooldownSeconds > 0) return;
-    setIsRefreshing(true);
     await Promise.all([
       lessonSummary.refetch(),
       rolloverSummary.refetch(),
@@ -55,15 +26,11 @@ function HomePage() {
       studentsSummary.refetch(),
       templatesSummary.refetch(),
     ]);
-    setIsRefreshing(false);
-    setCooldownSeconds(30);
   };
 
   return (
     <div className="space-y-6">
       <DashboardHeader
-        cooldownSeconds={cooldownSeconds}
-        isRefreshing={isRefreshing}
         onRefresh={handleRefresh}
       />
 

--- a/src/pages/message/template/hooks/useTemplateList.ts
+++ b/src/pages/message/template/hooks/useTemplateList.ts
@@ -49,7 +49,10 @@ export const useTemplateList = () => {
 
   // 변경사항이 있을 경우 확인 후 템플릿을 전환
   const handleSelectTemplate = async (nextTemplateId: number) => {
-    if (selectedTemplateId === nextTemplateId) return;
+    if (selectedTemplateId === nextTemplateId) {
+      selectTemplate(nextTemplateId);
+      return;
+    }
 
     const isDirty =
       mode === 'CREATE'

--- a/src/pages/message/template/hooks/useTemplateList.ts
+++ b/src/pages/message/template/hooks/useTemplateList.ts
@@ -49,11 +49,6 @@ export const useTemplateList = () => {
 
   // 변경사항이 있을 경우 확인 후 템플릿을 전환
   const handleSelectTemplate = async (nextTemplateId: number) => {
-    if (selectedTemplateId === nextTemplateId) {
-      selectTemplate(nextTemplateId);
-      return;
-    }
-
     const isDirty =
       mode === 'CREATE'
         ? isTemplateFormDirtyForCreate(form)
@@ -62,6 +57,16 @@ export const useTemplateList = () => {
             templates,
             selectedTemplateId,
           );
+    if (selectedTemplateId === nextTemplateId) {
+      if (!isDirty) {
+        selectTemplate(nextTemplateId);
+        return;
+      }
+
+      setPendingTemplateId(nextTemplateId);
+      setSwitchConfirmOpen(true);
+      return;
+    }
     if (!isDirty) {
       selectTemplate(nextTemplateId);
       return;
@@ -87,7 +92,6 @@ export const useTemplateList = () => {
 
   const handleCancelSwitch = () => {
     if (pendingTemplateId === null) return;
-    selectTemplate(pendingTemplateId);
     setPendingTemplateId(null);
     setSwitchConfirmOpen(false);
   };

--- a/src/pages/schedule/body/hooks/useAttendanceFlow.ts
+++ b/src/pages/schedule/body/hooks/useAttendanceFlow.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useDateModalStore } from '@/store/date/dateModalStore';
 import { useTimeModalStore } from '@/store/date/timeModalStore';
 import {
@@ -46,6 +47,7 @@ export function useAttendanceFlow({
   const { addToast } = useToastStore();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { open: openMakeupSendConfirm } = useMakeupMessageConfirmStore();
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     setStatus(attendanceStatus);
@@ -73,6 +75,10 @@ export function useAttendanceFlow({
       });
       setSavedStatus(status);
       onAttendanceUpdated(lessonId, status);
+      if (status === 'rollover') {
+        queryClient.invalidateQueries({ queryKey: ['rollover-lessons'] });
+        queryClient.invalidateQueries({ queryKey: ['home', 'rollover-lessons'] });
+      }
       addToast('success', '출결 상태가 성공적으로 저장되었습니다.');
     } catch (error) {
       console.error('Failed to update attendance:', error);

--- a/src/pages/schedule/body/hooks/useAttendanceFlow.ts
+++ b/src/pages/schedule/body/hooks/useAttendanceFlow.ts
@@ -10,6 +10,7 @@ import { useToastStore } from '@/store/feedback/toastStore';
 import { type MessageSendContext } from '@/store/message/messageSendModalStore';
 import { useMakeupMessageConfirmStore } from '@/store/message/makeupMessageConfirmStore';
 import type { MessageRecipient } from '@/store/message/messageSendStore';
+import { rolloverLessonKeys } from '@/shared/queryKeys/rolloverLessons';
 
 interface UseAttendanceFlowParams {
   attendanceStatus: string | null;
@@ -76,8 +77,12 @@ export function useAttendanceFlow({
       setSavedStatus(status);
       onAttendanceUpdated(lessonId, status);
       if (status === 'rollover') {
-        queryClient.invalidateQueries({ queryKey: ['rollover-lessons'] });
-        queryClient.invalidateQueries({ queryKey: ['home', 'rollover-lessons'] });
+        queryClient.invalidateQueries({
+          queryKey: rolloverLessonKeys.all,
+        });
+        queryClient.invalidateQueries({
+          queryKey: rolloverLessonKeys.home(),
+        });
       }
       addToast('success', '출결 상태가 성공적으로 저장되었습니다.');
     } catch (error) {

--- a/src/pages/schedule/header/components/CarryListSection/components/CarryListModal/components/CarryListTable.tsx
+++ b/src/pages/schedule/header/components/CarryListSection/components/CarryListModal/components/CarryListTable.tsx
@@ -21,10 +21,12 @@ const CarryListTable = ({ lessons, onRegister }: CarryListTableProps) => {
           lesson.name,
           lesson.class_type,
           formatToKoreanDate(lesson.start_at),
-          <NormalButton
-            text="등록"
-            onClick={() => onRegister(lesson.lesson_id)}
-          />,
+          <div className="flex justify-center">
+            <NormalButton
+              text="등록"
+              onClick={() => onRegister(lesson.lesson_id)}
+            />
+          </div>,
         ]);
       }}
     />

--- a/src/pages/schedule/header/components/CarryListSection/components/CarryListModal/hooks/useCarryList.ts
+++ b/src/pages/schedule/header/components/CarryListSection/components/CarryListModal/hooks/useCarryList.ts
@@ -2,21 +2,21 @@ import { useMemo } from 'react';
 import { getRollOverLessons, type LessonItem } from '@/shared/api/lessons';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { GetRolloverLessonsResponse } from '@/shared/api/lessons';
+import { rolloverLessonKeys } from '@/shared/queryKeys/rolloverLessons';
 
 // 이월 목록을 관리하는 커스텀 훅 - 이월된 레슨 목록을 가져오고 상태로 관리
 export const useCarryList = () => {
   const queryClient = useQueryClient();
-  const homeCache = queryClient.getQueryData<GetRolloverLessonsResponse>([
-    'home',
-    'rollover-lessons',
-  ]);
-  const homeCacheUpdatedAt = queryClient.getQueryState([
-    'home',
-    'rollover-lessons',
-  ])?.dataUpdatedAt;
+  const homeCache =
+    queryClient.getQueryData<GetRolloverLessonsResponse>(
+      rolloverLessonKeys.home(),
+    );
+  const homeCacheUpdatedAt = queryClient.getQueryState(
+    rolloverLessonKeys.home(),
+  )?.dataUpdatedAt;
 
   const { data, refetch } = useQuery({
-    queryKey: ['rollover-lessons'],
+    queryKey: rolloverLessonKeys.all,
     queryFn: () => getRollOverLessons(),
     initialData: homeCache,
     initialDataUpdatedAt: homeCache ? homeCacheUpdatedAt : undefined,

--- a/src/pages/schedule/header/index.tsx
+++ b/src/pages/schedule/header/index.tsx
@@ -1,5 +1,6 @@
 import CarryListSection from './components/CarryListSection';
 import SelectMonthSection from './components/SelectMonthSection';
+import RefreshButton from '@/shared/button/RefreshButton';
 
 interface CalendarHeaderProps {
   onRefreshLessons: () => Promise<void>;
@@ -15,40 +16,10 @@ function CalendarHeader({ onRefreshLessons, isRefreshing }: CalendarHeaderProps)
 
       {/* 2. 이월 목록 버튼과 모달을 포함하는 섹션 */}
       <div className="flex items-center gap-2">
-        <button
-          type="button"
-          onClick={onRefreshLessons}
-          disabled={isRefreshing}
-          className={`inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 ${
-            isRefreshing
-              ? 'border-gray-200 text-gray-400 cursor-not-allowed'
-              : 'border-primary text-primary hover:bg-primary/10 active:scale-95 active:bg-primary/20'
-          }`}
-        >
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 20 20"
-            fill="none"
-            aria-hidden="true"
-            className={isRefreshing ? 'animate-spin' : ''}
-          >
-            <path
-              d="M16 10a6 6 0 1 1-1.76-4.24"
-              stroke="currentColor"
-              strokeWidth="1.6"
-              strokeLinecap="round"
-            />
-            <path
-              d="M16 4v4h-4"
-              stroke="currentColor"
-              strokeWidth="1.6"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-          최신화
-        </button>
+        <RefreshButton
+          onRefresh={onRefreshLessons}
+          isRefreshingExternal={Boolean(isRefreshing)}
+        />
         <CarryListSection onRefreshLessons={onRefreshLessons} />
       </div>
     </div>

--- a/src/pages/schedule/hooks/useScheduleCalendar.ts
+++ b/src/pages/schedule/hooks/useScheduleCalendar.ts
@@ -55,6 +55,12 @@ export const useScheduleCalendar = () => {
 
   // 회차 데이터 불러오기
   const mapLessonsToCalendar = useCallback((response: GetLessonsResponse) => {
+    const normalizeAttendanceStatus = (value?: string) => {
+      if (!value) return null;
+      const normalized = value.toLowerCase();
+      return normalized === 'notyet' ? null : normalized;
+    };
+
     return response.days.reduce((acc, day) => {
       acc[day.date] = {
         date: day.date,
@@ -68,10 +74,7 @@ export const useScheduleCalendar = () => {
           id: lesson.lesson_id,
           paid_at: '',
           lesson_tag: lesson.lesson_tag,
-          attendance_status:
-            lesson.attendance_status === 'notyet'
-              ? null
-              : lesson.attendance_status,
+          attendance_status: normalizeAttendanceStatus(lesson.attendance_status),
         })),
       };
       return acc;

--- a/src/pages/schedule/hooks/useScheduleCalendar.ts
+++ b/src/pages/schedule/hooks/useScheduleCalendar.ts
@@ -60,6 +60,8 @@ export const useScheduleCalendar = () => {
       const normalized = value.toLowerCase();
       return normalized === 'notyet' ? null : normalized;
     };
+    const normalizeLessonTag = (value?: string) =>
+      value ? value.toLowerCase() : '';
 
     return response.days.reduce((acc, day) => {
       acc[day.date] = {
@@ -73,7 +75,7 @@ export const useScheduleCalendar = () => {
           lesson_index: lesson.lesson_index,
           id: lesson.lesson_id,
           paid_at: '',
-          lesson_tag: lesson.lesson_tag,
+          lesson_tag: normalizeLessonTag(lesson.lesson_tag),
           attendance_status: normalizeAttendanceStatus(lesson.attendance_status),
         })),
       };

--- a/src/pages/student/components/InvoiceListModal/components/invoiceCard/components/invoiceCardHeader.tsx
+++ b/src/pages/student/components/InvoiceListModal/components/invoiceCard/components/invoiceCardHeader.tsx
@@ -6,6 +6,7 @@ interface InvoiceCardHeaderProps {
   handleCancel: () => void;
   loading: boolean;
   handleSave: () => void;
+  isDirty: boolean;
   onSendMessage?: () => void;
 }
 
@@ -16,6 +17,7 @@ export default function InvoiceCardHeader({
   handleCancel,
   loading,
   handleSave,
+  isDirty,
   onSendMessage,
 }: InvoiceCardHeaderProps) {
   return (
@@ -33,7 +35,7 @@ export default function InvoiceCardHeader({
           <NormalButton
             text={loading ? '저장중...' : '저장'}
             onClick={handleSave}
-            disabled={loading}
+            disabled={loading || !isDirty}
           />
         </>
       )}

--- a/src/pages/student/components/InvoiceListModal/components/invoiceCard/hooks/useInvoiceCard.ts
+++ b/src/pages/student/components/InvoiceListModal/components/invoiceCard/hooks/useInvoiceCard.ts
@@ -20,6 +20,7 @@ interface UseInvoiceCardResult {
   setMethod: (next: PaymentMethod) => void;
   paidAtDate: string;
   setPaidAtDate: (next: string) => void;
+  isDirty: boolean;
   loading: boolean;
   validationError: string | null;
   handleCancel: () => void;
@@ -51,9 +52,8 @@ export default function useInvoiceCard(
   // 편집 상태 (props 기준으로 초기화)
   const [status, setStatus] = useState<InvoiceStatus>(invoice.status);
   const [method, setMethod] = useState<PaymentMethod>(invoice.method);
-  const [paidAtDate, setPaidAtDate] = useState<string>(
-    invoice.paidAt ? toDateOnly(invoice.paidAt) : '',
-  );
+  const initialPaidAtDate = invoice.paidAt ? toDateOnly(invoice.paidAt) : '';
+  const [paidAtDate, setPaidAtDate] = useState<string>(initialPaidAtDate);
 
   const { addToast } = useToastStore();
   const [loading, setLoading] = useState(false);
@@ -65,6 +65,13 @@ export default function useInvoiceCard(
     }
     return null;
   }, [status, method, paidAtDate]);
+
+  const isDirty = useMemo(() => {
+    const statusChanged = status !== invoice.status;
+    const methodChanged = method !== invoice.method;
+    const paidAtChanged = paidAtDate !== initialPaidAtDate;
+    return statusChanged || methodChanged || paidAtChanged;
+  }, [status, method, paidAtDate, invoice.status, invoice.method, initialPaidAtDate]);
 
   const handleCancel = () => {
     setIsEdit(false);
@@ -127,6 +134,7 @@ export default function useInvoiceCard(
     setMethod,
     paidAtDate,
     setPaidAtDate,
+    isDirty,
     loading,
     validationError,
     handleCancel,

--- a/src/pages/student/components/InvoiceListModal/components/invoiceCard/index.tsx
+++ b/src/pages/student/components/InvoiceListModal/components/invoiceCard/index.tsx
@@ -19,6 +19,7 @@ export default function InvoiceCard({
     setMethod,
     paidAtDate,
     setPaidAtDate,
+    isDirty,
     loading,
     validationError,
     handleCancel,
@@ -35,6 +36,7 @@ export default function InvoiceCard({
         handleCancel={handleCancel}
         loading={loading}
         handleSave={handleSave}
+        isDirty={isDirty}
         onSendMessage={onSendMessage ? () => onSendMessage(invoice) : undefined}
       />
 

--- a/src/pages/student/index.tsx
+++ b/src/pages/student/index.tsx
@@ -7,6 +7,7 @@ import ModalOpenButton from '@/shared/modal/ModalOpenButton';
 import { getAgeGroupLabel } from '@/utils/student/getAgeGroupLabel';
 import InvoiceListModal from './components/InvoiceListModal';
 import Chip from '@/shared/chip/Chip';
+import RefreshButton from '@/shared/button/RefreshButton';
 import { useQuery } from '@tanstack/react-query';
 
 const getAgeGroupTone = (ageGroup: Student['age_group'] | null) => {
@@ -45,40 +46,10 @@ function StudentPage() {
       {/* 1. 헤더 */}
       <div className="flex flex-wrap items-center justify-between gap-2">
         <ModalOpenButton text="신규학생 추가" openModal={openCreate} />
-        <button
-          type="button"
-          onClick={() => refetch()}
-          disabled={isFetching}
-          className={`inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 ${
-            isFetching
-              ? 'border-gray-200 text-gray-400 cursor-not-allowed'
-              : 'border-primary text-primary hover:bg-primary/10 active:scale-95 active:bg-primary/20'
-          }`}
-        >
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 20 20"
-            fill="none"
-            aria-hidden="true"
-            className={isFetching ? 'animate-spin' : ''}
-          >
-            <path
-              d="M16 10a6 6 0 1 1-1.76-4.24"
-              stroke="currentColor"
-              strokeWidth="1.6"
-              strokeLinecap="round"
-            />
-            <path
-              d="M16 4v4h-4"
-              stroke="currentColor"
-              strokeWidth="1.6"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-          최신화
-        </button>
+        <RefreshButton
+          onRefresh={async () => refetch()}
+          isRefreshingExternal={isFetching}
+        />
       </div>
 
       {/* 2. 테이블 */}

--- a/src/shared/button/RefreshButton.tsx
+++ b/src/shared/button/RefreshButton.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface RefreshButtonProps {
+  onRefresh: () => void | Promise<unknown>;
+  isRefreshingExternal?: boolean;
+  cooldownSeconds?: number;
+}
+
+const DEFAULT_COOLDOWN_SECONDS = 30;
+
+const RefreshButton = ({
+  onRefresh,
+  isRefreshingExternal = false,
+  cooldownSeconds = DEFAULT_COOLDOWN_SECONDS,
+}: RefreshButtonProps) => {
+  const [isRefreshingInternal, setIsRefreshingInternal] = useState(false);
+  const [cooldownLeft, setCooldownLeft] = useState(0);
+  const cooldownTimerRef = useRef<number | null>(null);
+
+  const isRefreshing = isRefreshingExternal || isRefreshingInternal;
+  const isDisabled = isRefreshing || cooldownLeft > 0;
+
+  useEffect(() => {
+    if (cooldownLeft <= 0) {
+      if (cooldownTimerRef.current !== null) {
+        window.clearInterval(cooldownTimerRef.current);
+        cooldownTimerRef.current = null;
+      }
+      return;
+    }
+
+    if (cooldownTimerRef.current === null) {
+      cooldownTimerRef.current = window.setInterval(() => {
+        setCooldownLeft((prev) => Math.max(0, prev - 1));
+      }, 1000);
+    }
+
+    return () => {
+      if (cooldownTimerRef.current !== null) {
+        window.clearInterval(cooldownTimerRef.current);
+        cooldownTimerRef.current = null;
+      }
+    };
+  }, [cooldownLeft]);
+
+  const handleClick = async () => {
+    if (isDisabled) return;
+    setIsRefreshingInternal(true);
+    try {
+      await onRefresh();
+      setCooldownLeft(cooldownSeconds);
+    } finally {
+      setIsRefreshingInternal(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={isDisabled}
+      className={`inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 ${
+        isDisabled
+          ? 'border-gray-200 text-gray-400 cursor-not-allowed'
+          : 'border-primary text-primary hover:bg-primary/10 active:scale-95 active:bg-primary/20'
+      }`}
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 20 20"
+        fill="none"
+        aria-hidden="true"
+        className={isRefreshing ? 'animate-spin' : ''}
+      >
+        <path
+          d="M16 10a6 6 0 1 1-1.76-4.24"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          strokeLinecap="round"
+        />
+        <path
+          d="M16 4v4h-4"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+      최신화
+      {cooldownLeft > 0 && (
+        <span className="text-[11px] text-gray-400">{cooldownLeft}s</span>
+      )}
+    </button>
+  );
+};
+
+export default RefreshButton;

--- a/src/shared/queryKeys/rolloverLessons.ts
+++ b/src/shared/queryKeys/rolloverLessons.ts
@@ -1,0 +1,4 @@
+export const rolloverLessonKeys = {
+  all: ['rollover-lessons'] as const,
+  home: () => ['home', 'rollover-lessons'] as const,
+};

--- a/src/store/message/messageTemplateStore.ts
+++ b/src/store/message/messageTemplateStore.ts
@@ -83,7 +83,18 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
     },
 
     selectTemplate: (id) => {
-      const selectedTemplate = get().templates.find((template) => template.id === id);
+      const { selectedTemplateId, templates } = get();
+      if (selectedTemplateId === id) {
+        set({
+          selectedTemplateId: null,
+          mode: 'CREATE',
+          form: getEmptyForm(),
+          menuOpenId: null,
+        });
+        return;
+      }
+
+      const selectedTemplate = templates.find((template) => template.id === id);
       if (!selectedTemplate) return;
 
       set({
@@ -143,13 +154,10 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
         set({
           templates: nextTemplates,
           totalCount: totalCount + 1,
-          selectedTemplateId: createdTemplate.id,
-          mode: 'UPDATE',
-          form: {
-            type: createdTemplate.type ?? DEFAULT_MESSAGE_TEMPLATE_TYPE,
-            title: createdTemplate.title,
-            content: createdTemplate.content,
-          },
+          selectedTemplateId: null,
+          mode: 'CREATE',
+          form: getEmptyForm(),
+          menuOpenId: null,
           templatesUpdatedAt: Date.now(),
         });
       } catch (error) {


### PR DESCRIPTION
**요약**
- 최신화 버튼 공통화로 여러 화면의 새로고침 UX를 통일하고, 쿨다운 처리를 정리했습니다.
- 출결/이월 데이터 동기화와 인보이스 저장 UX 개선 등 운영 흐름 안정성을 높였습니다.
- 템플릿 선택 토글 및 결제일 저장 포맷을 보완했습니다.

**주요 변경사항**
- 공통 새로고침 버튼 컴포넌트 도입 및 홈/수강/학생/일정 헤더 적용
- 이월 등록 버튼 정렬 개선
- 출결 상태 정규화 및 이월 관련 쿼리 무효화 추가
- 청구서 변경 여부 기반 저장 버튼 비활성화
- 결제일 `paid_at` 저장 시 ISO 타임존 오프셋 전송
- 메시지 템플릿 선택 토글 처리 및 폼 상태 초기화

**테스트/확인 포인트**
- 홈/수강/학생/일정 화면에서 새로고침 버튼 동작 및 쿨다운 표시 확인
- 이월 처리 후 목록이 즉시 갱신되는지 확인
- 출결 상태 표기와 저장 결과가 일치하는지 확인
- 청구서 변경 없이 저장 버튼이 비활성화되는지 확인
- 결제일 저장 시 서버에 타임존 포함 ISO 포맷으로 전달되는지 확인
- 메시지 템플릿 선택 토글 및 전송 폼 초기화 동작 확인
- 테스트 실행하지 않음