### PR TITLE
폼 UI 겹침 해소 및 수강 PATCH 전환, 메시지 템플릿 CRUD·전송 흐름 안정화

### DIFF
--- a/src/pages/course/modal/CourseForm.tsx
+++ b/src/pages/course/modal/CourseForm.tsx
@@ -234,14 +234,14 @@ export default function CourseForm({
 
       <FormField label="수강 시작 날짜">
         <div
-          className={`border rounded-sm py-1 px-2 flex justify-between items-center
+          className={`border rounded-sm py-1 px-2 flex items-center gap-2 min-w-0
         ${
           isViewMode
             ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
             : 'border-primary text-primary'
         }`}
         >
-          <p className="text-sm">
+          <p className="text-sm truncate">
             {form.start_date
               ? formatToKoreanDate(form.start_date)
               : '날짜를 선택해주세요.'}
@@ -252,7 +252,7 @@ export default function CourseForm({
               open();
             }}
             disabled={isViewMode}
-            className={`text-sm ${isViewMode && 'cursor-none'}`}
+            className={`text-sm shrink-0 ${isViewMode && 'cursor-none'}`}
           >
             선택
           </button>
@@ -319,14 +319,14 @@ export default function CourseForm({
 
           <FormField label="결제일">
             <div
-              className={`border rounded-sm py-1 px-2 flex justify-between
+              className={`border rounded-sm py-1 px-2 flex items-center gap-2 min-w-0
             ${
               isViewMode
                 ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
                 : 'border-primary text-primary'
             }`}
             >
-              <p className="text-sm">
+              <p className="text-sm truncate">
                 {form.invoice.paid_at
                   ? formatToKoreanDate(form.invoice.paid_at)
                   : '날짜를 선택해주세요.'}
@@ -337,7 +337,7 @@ export default function CourseForm({
                   open();
                 }}
                 disabled={isViewMode}
-                className={`text-sm ${isViewMode && 'cursor-none'}`}
+                className={`text-sm shrink-0 ${isViewMode && 'cursor-none'}`}
               >
                 선택
               </button>

--- a/src/pages/message/send/SendMessageForm/components/SendMessageHeader.tsx
+++ b/src/pages/message/send/SendMessageForm/components/SendMessageHeader.tsx
@@ -5,8 +5,8 @@ interface SendMessageHeaderProps {
   selectedStudentName: string;
   selectedStudentGroup: string;
   templates: MessageTemplate[];
-  selectedTemplateId: number | '';
-  onSelectTemplate: (id: number | '') => void;
+  selectedTemplateId: string;
+  onSelectTemplate: (id: string) => void;
   onApplyTemplate: () => void;
 }
 
@@ -30,8 +30,7 @@ function SendMessageHeader({
         <select
           value={selectedTemplateId}
           onChange={(event) => {
-            const value = event.target.value;
-            onSelectTemplate(value ? Number(value) : '');
+            onSelectTemplate(event.target.value);
           }}
           className="h-10 w-full min-w-0 rounded-md border border-gray-200 bg-white px-3 text-sm text-gray-700 outline-none focus:border-primary md:min-w-48"
         >

--- a/src/pages/message/send/SendMessageForm/index.tsx
+++ b/src/pages/message/send/SendMessageForm/index.tsx
@@ -8,6 +8,7 @@ import { useReservationFlow } from './hooks/useReservationFlow';
 import { useSendAction } from './hooks/useSendAction';
 import { useSelectedStudentSummary } from './hooks/useSelectedStudentSummary';
 import { useMessageTemplateStore } from '@/store/message/messageTemplateStore';
+import { useToastStore } from '@/store/feedback/toastStore';
 import { useEffect, useState } from 'react';
 
 function SendMessageForm() {
@@ -16,7 +17,8 @@ function SendMessageForm() {
   const fetchTemplates = useMessageTemplateStore(
     (state) => state.fetchTemplates,
   );
-  const [selectedTemplateId, setSelectedTemplateId] = useState<number | ''>('');
+  const { addToast } = useToastStore();
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string>('');
   const { selectedStudents, selectedStudentName, selectedStudentGroup } =
     useSelectedStudentSummary();
   const isSubmitDisabled = selectedStudents.length === 0 || !isContentValid;
@@ -38,15 +40,25 @@ function SendMessageForm() {
   });
   const handleApplyTemplate = () => {
     if (!selectedTemplateId) return;
+    const selectedTemplateIdNumber = Number(selectedTemplateId);
     const selectedTemplate = templates.find(
-      (template) => template.id === selectedTemplateId,
+      (template) =>
+        template.id === selectedTemplateIdNumber ||
+        String(template.id) === String(selectedTemplateId),
     );
-    if (!selectedTemplate) return;
+    if (!selectedTemplate) {
+      addToast('error', '선택한 템플릿을 불러오지 못했습니다.');
+      return;
+    }
+    if (!selectedTemplate.content) {
+      addToast('error', '선택한 템플릿에 내용이 없습니다.');
+      return;
+    }
     setContent(selectedTemplate.content);
   };
 
   useEffect(() => {
-    fetchTemplates();
+    fetchTemplates({ force: true });
   }, [fetchTemplates]);
 
   return (

--- a/src/pages/message/template/components/MessageTemplateList.tsx
+++ b/src/pages/message/template/components/MessageTemplateList.tsx
@@ -4,7 +4,6 @@ import {
 } from '@/constants/messageTemplate';
 import { useTemplateList } from '@/pages/message/template/hooks/useTemplateList';
 import ConfirmModal from '@/shared/modal/ConfirmModal';
-import { useToastStore } from '@/store/feedback/toastStore';
 import { useState } from 'react';
 import { IoTrashOutline } from 'react-icons/io5';
 import Chip from '@/shared/chip/Chip';
@@ -23,7 +22,6 @@ function MessageTemplateList() {
     onConfirmSwitch,
     onCancelSwitch,
   } = useTemplateList();
-  const { addToast } = useToastStore();
 
   const [confirmTargetId, setConfirmTargetId] = useState<number | null>(null);
 
@@ -38,7 +36,6 @@ function MessageTemplateList() {
   const handleConfirmDelete = () => {
     if (confirmTargetId === null) return;
     onDeleteTemplate(confirmTargetId);
-    addToast('success', '삭제되었습니다.');
     setConfirmTargetId(null);
   };
 

--- a/src/shared/api/courses/index.ts
+++ b/src/shared/api/courses/index.ts
@@ -50,12 +50,12 @@ export const createCourse = async (
 };
 
 // ====================
-// PUT : 수강 정보 수정하기
+// PATCH : 수강 정보 수정하기
 // ====================
 export const updateCourse = async (
   id: number,
   payload: Partial<CreateCoursePayload>,
 ): Promise<Course> => {
-  const res = await api.put<Course>(`/courses/${id}`, payload);
+  const res = await api.patch<Course>(`/courses/${id}`, payload);
   return res.data;
 };

--- a/src/shared/api/message/index.ts
+++ b/src/shared/api/message/index.ts
@@ -17,12 +17,6 @@ export type {
   UpdateMessageTemplatePayload,
 } from './message.types';
 
-const TEMPLATE_TYPE_TO_API: Record<string, string> = {
-  ATTENDANCE: 'attended',
-  ABSENT: 'absent',
-  MAKEUP: 'makeup',
-};
-
 const TEMPLATE_TYPE_FROM_API: Record<string, MessageTemplate['type']> = {
   attended: 'ATTENDANCE',
   attendance: 'ATTENDANCE',
@@ -38,7 +32,7 @@ const normalizeTemplateTypeFromApi = (type: string): MessageTemplate['type'] => 
 };
 
 const normalizeTemplateTypeToApi = (type: MessageTemplate['type']) =>
-  TEMPLATE_TYPE_TO_API[type] ?? String(type).toLowerCase();
+  String(type).trim().toUpperCase();
 
 const mapMessageTemplate = (
   template: MessageTemplateApiResponse,
@@ -150,4 +144,13 @@ export const updateMessageTemplate = async (
   );
 
   return mapMessageTemplate(res.data);
+};
+
+// ====================
+// DELETE : 메시지 템플릿 삭제
+// ====================
+export const deleteMessageTemplate = async (
+  templateId: number,
+): Promise<void> => {
+  await api.delete(`/messages/templates/${templateId}`);
 };

--- a/src/shared/form/Select.tsx
+++ b/src/shared/form/Select.tsx
@@ -97,13 +97,15 @@ function Select({ options, value, onChange, disabled = false }: SelectProps) {
         ref={triggerRef}
         disabled={disabled}
         onClick={() => !disabled && setIsOpen((prev) => !prev)}
-        className={` w-full rounded-sm border px-2 py-1.5 text-left text-sm transition-colors ${
+        className={`relative w-full rounded-sm border px-2 py-1.5 pr-9 text-left text-sm transition-colors ${
           disabled
             ? 'bg-gray-100 text-gray-400 cursor-not-allowed border-gray-400'
             : 'bg-white text-primary border-primary hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
         }`}
       >
-        <span className={disabled ? 'text-gray-400' : 'text-primary'}>
+        <span
+          className={`block truncate ${disabled ? 'text-gray-400' : 'text-primary'}`}
+        >
           {selectedLabel}
         </span>
         <span

--- a/src/store/message/messageTemplateStore.ts
+++ b/src/store/message/messageTemplateStore.ts
@@ -4,9 +4,11 @@ import {
 } from '@/constants/messageTemplate';
 import {
   createMessageTemplate,
+  deleteMessageTemplate,
   getMessageTemplates,
   updateMessageTemplate,
 } from '@/shared/api/message';
+import { useToastStore } from '@/store/feedback/toastStore';
 import type { MessageTemplate } from '@/types/messageTemplate';
 import { create } from 'zustand';
 
@@ -37,7 +39,7 @@ interface MessageTemplateStore {
   closeMenu: () => void;
   addTemplate: () => Promise<void>;
   updateTemplate: () => Promise<void>;
-  deleteTemplate: (id: number) => void;
+  deleteTemplate: (id: number) => Promise<void>;
 }
 
 const DEFAULT_PAGE = 1;
@@ -208,13 +210,28 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
           },
           templatesUpdatedAt: Date.now(),
         });
+        useToastStore.getState().addToast('success', '템플릿이 수정되었습니다.');
       } catch (error) {
         console.error('Failed to update message template:', error);
+        useToastStore
+          .getState()
+          .addToast('error', '템플릿 수정에 실패했습니다.');
       }
     },
 
-    deleteTemplate: (id) => {
+    deleteTemplate: async (id) => {
       const { templates, selectedTemplateId, totalCount } = get();
+
+      try {
+        await deleteMessageTemplate(id);
+      } catch (error) {
+        console.error('Failed to delete message template:', error);
+        useToastStore
+          .getState()
+          .addToast('error', '템플릿 삭제에 실패했습니다.');
+        return;
+      }
+
       const nextTemplates = templates.filter((template) => template.id !== id);
       const nextTotalCount = Math.max(0, totalCount - 1);
 
@@ -228,6 +245,7 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
           menuOpenId: null,
           templatesUpdatedAt: Date.now(),
         });
+        useToastStore.getState().addToast('success', '삭제되었습니다.');
         return;
       }
 
@@ -241,6 +259,7 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
           menuOpenId: null,
           templatesUpdatedAt: Date.now(),
         });
+        useToastStore.getState().addToast('success', '삭제되었습니다.');
         return;
       }
 
@@ -250,6 +269,7 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
         menuOpenId: null,
         templatesUpdatedAt: Date.now(),
       });
+      useToastStore.getState().addToast('success', '삭제되었습니다.');
     },
   }),
 );


### PR DESCRIPTION
**요약**
- 폼 입력/선택 UI 겹침 문제를 해소하고 수강 수정 요청을 백엔드 스펙에 맞게 정리했습니다.
- 메시지 템플릿 CRUD 흐름과 전송 화면 템플릿 적용 안정성을 개선했습니다.

**주요 변경사항**
- 셀렉트 및 수강 날짜 필드에서 텍스트·버튼 겹침을 방지하도록 레이아웃/말줄임 처리
- 수강 수정 API 호출을 `PATCH`로 전환
- 메시지 템플릿 타입 전송 형식을 백엔드 enum에 맞게 정규화
- 메시지 템플릿 삭제를 실제 API 호출로 처리하고 중복 토스트 제거
- 메시지 전송 화면에서 템플릿 선택/불러오기 흐름 안정화 및 최신 목록 강제 갱신

**테스트/확인 포인트**
- 수강 생성/상세 화면에서 셀렉트, 날짜 선택 영역 겹침 재현 여부
- 수강 정보 수정 시 정상적으로 PATCH 요청되는지
- 메시지 템플릿 생성/수정/삭제 후 목록 반영 및 토스트 표시
- 메시지 전송 화면에서 새로 만든 템플릿 선택·불러오기 동작

테스트 실행하지 않음