### PR TITLE
청구서 편집 액션 정리 및 문자 템플릿 선택 UX·API 안정성 개선

### DIFF
--- a/src/pages/message/send/SendMessageForm/components/SendMessageHeader.tsx
+++ b/src/pages/message/send/SendMessageForm/components/SendMessageHeader.tsx
@@ -1,5 +1,11 @@
 import NormalButton from '@/shared/button/NormalButton';
+import Chip from '@/shared/chip/Chip';
+import {
+  MESSAGE_TEMPLATE_TYPE_LABELS,
+  MESSAGE_TEMPLATE_TYPE_TONES,
+} from '@/constants/messageTemplate';
 import type { MessageTemplate } from '@/types/messageTemplate';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 interface SendMessageHeaderProps {
   selectedStudentName: string;
@@ -18,6 +24,26 @@ function SendMessageHeader({
   onSelectTemplate,
   onApplyTemplate,
 }: SendMessageHeaderProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+  const selectedTemplate = useMemo(
+    () => templates.find((template) => String(template.id) === selectedTemplateId),
+    [templates, selectedTemplateId],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (!target) return;
+      if (!dropdownRef.current?.contains(target)) {
+        setIsOpen(false);
+      }
+    };
+    window.addEventListener('mousedown', handleClickOutside);
+    return () => window.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen]);
+
   return (
     <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between flex-wrap">
       <div>
@@ -27,20 +53,85 @@ function SendMessageHeader({
         </p>
       </div>
       <div className="flex w-full flex-col gap-2 md:w-auto md:flex-row md:items-center">
-        <select
-          value={selectedTemplateId}
-          onChange={(event) => {
-            onSelectTemplate(event.target.value);
-          }}
-          className="h-10 w-full min-w-0 rounded-md border border-gray-200 bg-white px-3 text-sm text-gray-700 outline-none focus:border-primary md:min-w-48"
-        >
-          <option value="">템플릿 선택</option>
-          {templates.map((template) => (
-            <option key={template.id} value={template.id}>
-              {template.title}
-            </option>
-          ))}
-        </select>
+        <div className="relative w-full md:min-w-48" ref={dropdownRef}>
+          <button
+            type="button"
+            onClick={() => setIsOpen((prev) => !prev)}
+            className="flex h-10 w-full items-center justify-between rounded-md border border-gray-200 bg-white px-3 text-sm text-gray-700 outline-none transition focus:border-primary"
+          >
+            {selectedTemplate ? (
+              <span className="flex min-w-0 items-center gap-2">
+                <Chip
+                  label={MESSAGE_TEMPLATE_TYPE_LABELS[selectedTemplate.type]}
+                  tone={MESSAGE_TEMPLATE_TYPE_TONES[selectedTemplate.type]}
+                />
+                <span className="min-w-0 truncate text-gray-900">
+                  {selectedTemplate.title}
+                </span>
+              </span>
+            ) : (
+              <span className="text-gray-500">템플릿 선택</span>
+            )}
+            <span
+              className={`ml-2 text-xs text-gray-500 transition ${
+                isOpen ? 'rotate-180' : ''
+              }`}
+              aria-hidden
+            >
+              ▼
+            </span>
+          </button>
+          {isOpen && (
+            <div className="absolute z-10 mt-2 w-full overflow-hidden rounded-md border border-gray-200 bg-white shadow-[0_6px_20px_rgba(0,0,0,0.12)]">
+              <ul className="flex max-h-64 flex-col gap-1 overflow-auto p-2 text-sm overscroll-contain">
+                <li>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onSelectTemplate('');
+                      setIsOpen(false);
+                    }}
+                    className={`flex w-full items-center rounded-md px-3 py-2 text-left transition ${
+                      selectedTemplateId === ''
+                        ? 'bg-gray-100 text-gray-900'
+                        : 'text-gray-600 hover:bg-gray-50'
+                    }`}
+                  >
+                    템플릿 선택
+                  </button>
+                </li>
+                {templates.map((template) => {
+                  const isSelected =
+                    String(template.id) === String(selectedTemplateId);
+                  return (
+                    <li key={template.id}>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          onSelectTemplate(String(template.id));
+                          setIsOpen(false);
+                        }}
+                        className={`flex w-full items-center gap-2 rounded-md border px-3 py-2 text-left transition ${
+                          isSelected
+                            ? 'border-primary bg-primary/10 text-primary shadow-[0_0_0_1px_rgba(97,129,216,0.35)]'
+                            : 'border-transparent text-gray-700 hover:border-gray-200 hover:bg-gray-100'
+                        }`}
+                      >
+                        <Chip
+                          label={MESSAGE_TEMPLATE_TYPE_LABELS[template.type]}
+                          tone={MESSAGE_TEMPLATE_TYPE_TONES[template.type]}
+                        />
+                        <span className="min-w-0 truncate">
+                          {template.title}
+                        </span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+        </div>
         <NormalButton
           text="템플릿 불러오기"
           onClick={onApplyTemplate}

--- a/src/pages/message/send/SendMessageForm/components/SendMessageHeader.tsx
+++ b/src/pages/message/send/SendMessageForm/components/SendMessageHeader.tsx
@@ -1,11 +1,11 @@
 import NormalButton from '@/shared/button/NormalButton';
 import Chip from '@/shared/chip/Chip';
+import Select from '@/shared/form/Select';
 import {
   MESSAGE_TEMPLATE_TYPE_LABELS,
   MESSAGE_TEMPLATE_TYPE_TONES,
 } from '@/constants/messageTemplate';
 import type { MessageTemplate } from '@/types/messageTemplate';
-import { useEffect, useMemo, useRef, useState } from 'react';
 
 interface SendMessageHeaderProps {
   selectedStudentName: string;
@@ -24,25 +24,13 @@ function SendMessageHeader({
   onSelectTemplate,
   onApplyTemplate,
 }: SendMessageHeaderProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement | null>(null);
-  const selectedTemplate = useMemo(
-    () => templates.find((template) => String(template.id) === selectedTemplateId),
-    [templates, selectedTemplateId],
+  const options = templates.map((template) => ({
+    value: String(template.id),
+    label: template.title,
+  }));
+  const templateMap = new Map(
+    templates.map((template) => [String(template.id), template]),
   );
-
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as Node | null;
-      if (!target) return;
-      if (!dropdownRef.current?.contains(target)) {
-        setIsOpen(false);
-      }
-    };
-    window.addEventListener('mousedown', handleClickOutside);
-    return () => window.removeEventListener('mousedown', handleClickOutside);
-  }, [isOpen]);
 
   return (
     <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between flex-wrap">
@@ -53,84 +41,49 @@ function SendMessageHeader({
         </p>
       </div>
       <div className="flex w-full flex-col gap-2 md:w-auto md:flex-row md:items-center">
-        <div className="relative w-full md:min-w-48" ref={dropdownRef}>
-          <button
-            type="button"
-            onClick={() => setIsOpen((prev) => !prev)}
-            className="flex h-10 w-full items-center justify-between rounded-md border border-gray-200 bg-white px-3 text-sm text-gray-700 outline-none transition focus:border-primary"
-          >
-            {selectedTemplate ? (
-              <span className="flex min-w-0 items-center gap-2">
-                <Chip
-                  label={MESSAGE_TEMPLATE_TYPE_LABELS[selectedTemplate.type]}
-                  tone={MESSAGE_TEMPLATE_TYPE_TONES[selectedTemplate.type]}
-                />
-                <span className="min-w-0 truncate text-gray-900">
-                  {selectedTemplate.title}
+        <div className="w-full md:min-w-48">
+          <Select
+            options={options}
+            value={selectedTemplateId}
+            onChange={onSelectTemplate}
+            placeholder="템플릿 선택"
+            renderValue={(label, option) => {
+              if (!option || option.value === '') {
+                return <span className="text-gray-500">템플릿 선택</span>;
+              }
+              const template = templateMap.get(option.value);
+              if (!template) return <span className="text-gray-500">{label}</span>;
+              return (
+                <span className="flex min-w-0 items-center gap-2 text-gray-900">
+                  <Chip
+                    label={MESSAGE_TEMPLATE_TYPE_LABELS[template.type]}
+                    tone={MESSAGE_TEMPLATE_TYPE_TONES[template.type]}
+                  />
+                  <span className="min-w-0 truncate">{template.title}</span>
                 </span>
-              </span>
-            ) : (
-              <span className="text-gray-500">템플릿 선택</span>
-            )}
-            <span
-              className={`ml-2 text-xs text-gray-500 transition ${
-                isOpen ? 'rotate-180' : ''
-              }`}
-              aria-hidden
-            >
-              ▼
-            </span>
-          </button>
-          {isOpen && (
-            <div className="absolute z-10 mt-2 w-full overflow-hidden rounded-md border border-gray-200 bg-white shadow-[0_6px_20px_rgba(0,0,0,0.12)]">
-              <ul className="flex max-h-64 flex-col gap-1 overflow-auto p-2 text-sm overscroll-contain">
-                <li>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      onSelectTemplate('');
-                      setIsOpen(false);
-                    }}
-                    className={`flex w-full items-center rounded-md px-3 py-2 text-left transition ${
-                      selectedTemplateId === ''
-                        ? 'bg-gray-100 text-gray-900'
-                        : 'text-gray-600 hover:bg-gray-50'
-                    }`}
-                  >
+              );
+            }}
+            renderOption={(option, { isSelected }) => {
+              if (option.value === '') {
+                return (
+                  <span className={isSelected ? 'text-gray-900' : 'text-gray-600'}>
                     템플릿 선택
-                  </button>
-                </li>
-                {templates.map((template) => {
-                  const isSelected =
-                    String(template.id) === String(selectedTemplateId);
-                  return (
-                    <li key={template.id}>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          onSelectTemplate(String(template.id));
-                          setIsOpen(false);
-                        }}
-                        className={`flex w-full items-center gap-2 rounded-md border px-3 py-2 text-left transition ${
-                          isSelected
-                            ? 'border-primary bg-primary/10 text-primary shadow-[0_0_0_1px_rgba(97,129,216,0.35)]'
-                            : 'border-transparent text-gray-700 hover:border-gray-200 hover:bg-gray-100'
-                        }`}
-                      >
-                        <Chip
-                          label={MESSAGE_TEMPLATE_TYPE_LABELS[template.type]}
-                          tone={MESSAGE_TEMPLATE_TYPE_TONES[template.type]}
-                        />
-                        <span className="min-w-0 truncate">
-                          {template.title}
-                        </span>
-                      </button>
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
-          )}
+                  </span>
+                );
+              }
+              const template = templateMap.get(option.value);
+              if (!template) return option.label;
+              return (
+                <span className="flex items-center gap-2">
+                  <Chip
+                    label={MESSAGE_TEMPLATE_TYPE_LABELS[template.type]}
+                    tone={MESSAGE_TEMPLATE_TYPE_TONES[template.type]}
+                  />
+                  <span className="min-w-0 truncate">{template.title}</span>
+                </span>
+              );
+            }}
+          />
         </div>
         <NormalButton
           text="템플릿 불러오기"

--- a/src/pages/message/template/components/MessageTemplateForm.tsx
+++ b/src/pages/message/template/components/MessageTemplateForm.tsx
@@ -30,7 +30,7 @@ function MessageTemplateForm() {
   }, [isTypeOpen]);
 
   return (
-    <div className="flex flex-col gap-7.5">
+    <div className="flex flex-col gap-5 md:gap-7.5">
       <div className="flex min-h-0 h-full flex-col gap-4">
         {/* 1. 유형 입력 필드 */}
         <div className="flex flex-col gap-2" ref={typeMenuRef}>
@@ -58,7 +58,7 @@ function MessageTemplateForm() {
             </button>
             {isTypeOpen && (
               <div className="absolute z-10 mt-2 w-full overflow-hidden rounded-md border border-gray-200 bg-white shadow-[0_6px_20px_rgba(0,0,0,0.12)]">
-                <ul className="flex flex-col gap-1 p-2 text-sm">
+                <ul className="flex max-h-72 flex-col gap-1 overflow-auto p-2 text-sm overscroll-contain">
                   {MESSAGE_TEMPLATE_TYPES.map((type) => {
                     const isSelected = form.type === type;
                     return (
@@ -107,7 +107,7 @@ function MessageTemplateForm() {
           value={form.content}
           onChange={(event) => setFormField('content', event.target.value)}
           placeholder="문자 내용을 입력하세요."
-          className="h-full min-h-0 w-full resize-none rounded-sm bg-gray-100 px-4 py-3 text-base leading-6 outline-none focus:ring-1 focus:ring-gray-300"
+          className="min-h-48 w-full resize-none rounded-sm bg-gray-100 px-4 py-3 text-base leading-6 outline-none focus:ring-1 focus:ring-gray-300 md:h-full md:min-h-0"
         />
       </div>
 

--- a/src/pages/message/template/components/MessageTemplateForm.tsx
+++ b/src/pages/message/template/components/MessageTemplateForm.tsx
@@ -4,94 +4,54 @@ import {
   MESSAGE_TEMPLATE_TYPES,
 } from '@/constants/messageTemplate';
 import { useTemplateForm } from '@/pages/message/template/hooks/useTemplateForm';
-import { useEffect, useRef, useState } from 'react';
 import Chip from '@/shared/chip/Chip';
+import Select from '@/shared/form/Select';
 
 // 문자 템플릿 폼 컴포넌트 - 제목과 내용 입력, 제출 버튼 포함
 function MessageTemplateForm() {
   // 템플릿 폼 상태와 관련 함수들을 커스텀 훅에서 가져옴
   const { form, mode, isSubmitEnabled, setFormField, handleSubmit } =
     useTemplateForm();
-  const [isTypeOpen, setIsTypeOpen] = useState(false);
-  const typeMenuRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!isTypeOpen) return;
-
-    const handleOutsideClick = (event: MouseEvent) => {
-      if (!typeMenuRef.current) return;
-      if (!typeMenuRef.current.contains(event.target as Node)) {
-        setIsTypeOpen(false);
-      }
-    };
-
-    window.addEventListener('mousedown', handleOutsideClick);
-    return () => window.removeEventListener('mousedown', handleOutsideClick);
-  }, [isTypeOpen]);
+  const typeOptions = MESSAGE_TEMPLATE_TYPES.map((type) => ({
+    value: type,
+    label: MESSAGE_TEMPLATE_TYPE_LABELS[type],
+  }));
 
   return (
     <div className="flex flex-col gap-5 md:gap-7.5">
       <div className="flex min-h-0 h-full flex-col gap-4">
         {/* 1. 유형 입력 필드 */}
-        <div className="flex flex-col gap-2" ref={typeMenuRef}>
-          <div className="relative">
-            <button
-              id="message-template-type"
-              type="button"
-              onClick={() => setIsTypeOpen((prev) => !prev)}
-              className="flex w-full items-center justify-between rounded-sm border border-transparent bg-gray-100 px-4 py-3 text-base text-gray-900 outline-none transition focus:ring-1 focus:ring-gray-300"
-            >
-              <span className="flex items-center gap-2 truncate">
+        <div className="flex flex-col gap-2">
+          <Select
+            options={typeOptions}
+            value={form.type}
+            onChange={(value) => setFormField('type', value)}
+            renderValue={(label) => (
+              <span className="flex items-center gap-2">
                 <Chip
-                  label={MESSAGE_TEMPLATE_TYPE_LABELS[form.type]}
+                  label={label}
                   tone={MESSAGE_TEMPLATE_TYPE_TONES[form.type]}
                 />
               </span>
-              <span
-                className={`ml-3 text-xs text-gray-500 transition ${
-                  isTypeOpen ? 'rotate-180' : ''
-                }`}
-                aria-hidden
-              >
-                ▼
-              </span>
-            </button>
-            {isTypeOpen && (
-              <div className="absolute z-10 mt-2 w-full overflow-hidden rounded-md border border-gray-200 bg-white shadow-[0_6px_20px_rgba(0,0,0,0.12)]">
-                <ul className="flex max-h-72 flex-col gap-1 overflow-auto p-2 text-sm overscroll-contain">
-                  {MESSAGE_TEMPLATE_TYPES.map((type) => {
-                    const isSelected = form.type === type;
-                    return (
-                      <li key={type}>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setFormField('type', type);
-                            setIsTypeOpen(false);
-                          }}
-                          className={`flex w-full items-center justify-between rounded-md border px-3 py-2 text-left transition ${
-                            isSelected
-                              ? 'border-primary bg-primary/10 text-primary shadow-[0_0_0_1px_rgba(97,129,216,0.35)]'
-                              : 'border-transparent text-gray-700 hover:border-gray-200 hover:bg-gray-100'
-                          }`}
-                        >
-                          <span className="flex items-center gap-2">
-                            <Chip
-                              label={MESSAGE_TEMPLATE_TYPE_LABELS[type]}
-                              tone={MESSAGE_TEMPLATE_TYPE_TONES[type]}
-                            />
-                          </span>
-                          {isSelected && (
-                            <span className="text-xs text-primary">선택됨</span>
-                          )}
-                        </button>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </div>
             )}
-          </div>
+            renderOption={(option, { isSelected }) => (
+              <span className="flex w-full items-center justify-between">
+                <span className="flex items-center gap-2">
+                  <Chip
+                    label={option.label}
+                    tone={
+                      MESSAGE_TEMPLATE_TYPE_TONES[
+                        option.value as (typeof MESSAGE_TEMPLATE_TYPES)[number]
+                      ]
+                    }
+                  />
+                </span>
+                {isSelected && (
+                  <span className="text-xs text-primary">선택됨</span>
+                )}
+              </span>
+            )}
+          />
         </div>
 
         {/* 2. 제목 입력 필드 */}

--- a/src/pages/message/template/components/MessageTemplateList.tsx
+++ b/src/pages/message/template/components/MessageTemplateList.tsx
@@ -42,7 +42,7 @@ function MessageTemplateList() {
   return (
     <div className="flex min-h-0 h-full flex-col gap-4">
       {/* 1. 템플릿 목록 */}
-      <div className="relative min-h-0 flex-1 overflow-y-auto pr-1 pl-1 pb-1">
+      <div className="relative min-h-0 flex-1 md:overflow-y-auto md:pr-1 md:pl-1 md:pb-1">
         <div className="flex flex-col gap-3 py-1">
           {isLoadingTemplates && templates.length === 0 && (
             <div className="rounded-sm bg-gray-100 px-4 py-3 text-sm text-gray-500">

--- a/src/pages/message/template/components/MessageTemplateList.tsx
+++ b/src/pages/message/template/components/MessageTemplateList.tsx
@@ -131,9 +131,10 @@ function MessageTemplateList() {
       <ConfirmModal
         isOpen={isSwitchConfirmOpen}
         title="저장되지 않은 변경사항이 있습니다."
-        description="저장 후 템플릿을 전환할까요?"
-        confirmText="저장 후 전환"
-        cancelText="그대로 전환"
+        description="변경 사항이 사라집니다. 계속하시겠습니까?"
+        confirmText="변경 사항 버리기"
+        cancelText="계속 수정"
+        isDanger
         onConfirm={onConfirmSwitch}
         onCancel={onCancelSwitch}
       />

--- a/src/pages/message/template/hooks/useTemplateList.ts
+++ b/src/pages/message/template/hooks/useTemplateList.ts
@@ -1,11 +1,9 @@
 import { useMessageTemplateStore } from '@/store/message/messageTemplateStore';
 import { useState } from 'react';
 import {
-  canSubmitTemplateForm,
   isTemplateFormDirtyAgainstSelected,
   isTemplateFormDirtyForCreate,
 } from './templateFormUtils';
-import { useToastStore } from '@/store/feedback/toastStore';
 
 // 템플릿 목록과 선택 동작을 다루는 훅
 export const useTemplateList = () => {
@@ -29,23 +27,10 @@ export const useTemplateList = () => {
   const openCreateMode = useMessageTemplateStore(
     (state) => state.openCreateMode,
   );
-  const addTemplate = useMessageTemplateStore((state) => state.addTemplate);
-  const updateTemplate = useMessageTemplateStore(
-    (state) => state.updateTemplate,
-  );
   const [switchConfirmOpen, setSwitchConfirmOpen] = useState(false);
   const [pendingTemplateId, setPendingTemplateId] = useState<number | null>(
     null,
   );
-
-  // 현재 모드에 따라 생성/수정을 수행
-  const handleSubmit = async () => {
-    if (mode === 'CREATE') {
-      await addTemplate();
-      return;
-    }
-    updateTemplate();
-  };
 
   // 변경사항이 있을 경우 확인 후 템플릿을 전환
   const handleSelectTemplate = async (nextTemplateId: number) => {
@@ -76,15 +61,9 @@ export const useTemplateList = () => {
     setSwitchConfirmOpen(true);
   };
 
-  const handleConfirmSwitch = async () => {
-    const { addToast } = useToastStore();
+  const handleConfirmSwitch = () => {
     if (pendingTemplateId === null) return;
-    const canSubmit = canSubmitTemplateForm(form);
-    if (!canSubmit) {
-      addToast('error', '제목과 내용을 모두 입력해야 저장할 수 있습니다.');
-      return;
-    }
-    await handleSubmit();
+    // 변경 사항을 버리고 선택 전환
     selectTemplate(pendingTemplateId);
     setPendingTemplateId(null);
     setSwitchConfirmOpen(false);

--- a/src/pages/message/template/index.tsx
+++ b/src/pages/message/template/index.tsx
@@ -15,14 +15,15 @@ function MessageTemplatePage() {
   }, [fetchTemplates]);
 
   return (
-    <div className="rounded-xl border border-gray-200 bg-white p-6">
-      <div className="flex h-155 flex-col overflow-hidden">
+    <div className="rounded-xl border border-gray-200 bg-white p-4 sm:p-6">
+      <div className="flex h-auto flex-col overflow-hidden md:h-155">
         {/* 1. 페이지 헤더 컴포넌트 */}
         <MessageTemplateHeader />
 
         {/* 2. 본문 컴포넌트 - 폼과 리스트 컴포넌트 포함 */}
-        <div className="grid min-h-0 flex-1 grid-cols-[1fr_1.15fr] gap-6">
+        <div className="grid min-h-0 flex-1 grid-cols-1 gap-10 md:grid-cols-[1fr_1.15fr] md:gap-6">
           <MessageTemplateList />
+          <hr className="border-gray-200 md:hidden" />
           <MessageTemplateForm />
         </div>
       </div>

--- a/src/pages/student/components/InvoiceListModal/components/invoiceCard/components/InvoiceEditForm.tsx
+++ b/src/pages/student/components/InvoiceListModal/components/invoiceCard/components/InvoiceEditForm.tsx
@@ -1,6 +1,7 @@
 import FormField from '@/shared/form/FormField';
 import Select from '@/shared/form/Select';
 import TextInput from '@/shared/form/TextInput';
+import NormalButton from '@/shared/button/NormalButton';
 import { PAYMENT_METHOD_OPTIONS, PAYMENT_STATUS_OPTIONS } from '@/constants/invoice';
 import type { InvoiceStatus, PaymentMethod } from '@/types/invoice';
 
@@ -12,6 +13,10 @@ interface InvoiceEditFormProps {
   paidAtDate: string;
   setPaidAtDate: (next: string) => void;
   validationError: string | null;
+  onCancel: () => void;
+  onSave: () => void;
+  loading: boolean;
+  isDirty: boolean;
 }
 
 // 청구서 편집 폼 컴포넌트
@@ -23,6 +28,10 @@ export default function InvoiceEditForm({
   paidAtDate,
   setPaidAtDate,
   validationError,
+  onCancel,
+  onSave,
+  loading,
+  isDirty,
 }: InvoiceEditFormProps) {
   return (
     <div className="mt-4 pt-4 border-t border-gray-200 space-y-3">
@@ -70,6 +79,15 @@ export default function InvoiceEditForm({
       {validationError && (
         <div className="text-sm text-red-500">{validationError}</div>
       )}
+
+      <div className="flex justify-end gap-2">
+        <NormalButton text="취소" onClick={onCancel} />
+        <NormalButton
+          text={loading ? '저장중...' : '저장'}
+          onClick={onSave}
+          disabled={loading || !isDirty}
+        />
+      </div>
     </div>
   );
 }

--- a/src/pages/student/components/InvoiceListModal/components/invoiceCard/components/invoiceCardHeader.tsx
+++ b/src/pages/student/components/InvoiceListModal/components/invoiceCard/components/invoiceCardHeader.tsx
@@ -3,10 +3,6 @@ import NormalButton from '@/shared/button/NormalButton';
 interface InvoiceCardHeaderProps {
   isEdit: boolean;
   setIsEdit: (isEdit: boolean) => void;
-  handleCancel: () => void;
-  loading: boolean;
-  handleSave: () => void;
-  isDirty: boolean;
   onSendMessage?: () => void;
 }
 
@@ -14,10 +10,6 @@ interface InvoiceCardHeaderProps {
 export default function InvoiceCardHeader({
   isEdit,
   setIsEdit,
-  handleCancel,
-  loading,
-  handleSave,
-  isDirty,
   onSendMessage,
 }: InvoiceCardHeaderProps) {
   return (

--- a/src/pages/student/components/InvoiceListModal/components/invoiceCard/components/invoiceCardHeader.tsx
+++ b/src/pages/student/components/InvoiceListModal/components/invoiceCard/components/invoiceCardHeader.tsx
@@ -29,16 +29,7 @@ export default function InvoiceCardHeader({
           ) : null}
           <NormalButton text="수정하기" onClick={() => setIsEdit(true)} />
         </>
-      ) : (
-        <>
-          <NormalButton text="취소" onClick={handleCancel} />
-          <NormalButton
-            text={loading ? '저장중...' : '저장'}
-            onClick={handleSave}
-            disabled={loading || !isDirty}
-          />
-        </>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/src/pages/student/components/InvoiceListModal/components/invoiceCard/index.tsx
+++ b/src/pages/student/components/InvoiceListModal/components/invoiceCard/index.tsx
@@ -53,6 +53,10 @@ export default function InvoiceCard({
           paidAtDate={paidAtDate}
           setPaidAtDate={setPaidAtDate}
           validationError={validationError}
+          onCancel={handleCancel}
+          onSave={handleSave}
+          loading={loading}
+          isDirty={isDirty}
         />
       )}
     </div>

--- a/src/pages/student/components/InvoiceListModal/components/invoiceCard/index.tsx
+++ b/src/pages/student/components/InvoiceListModal/components/invoiceCard/index.tsx
@@ -33,10 +33,6 @@ export default function InvoiceCard({
       <InvoiceCardHeader
         isEdit={isEdit}
         setIsEdit={setIsEdit}
-        handleCancel={handleCancel}
-        loading={loading}
-        handleSave={handleSave}
-        isDirty={isDirty}
         onSendMessage={onSendMessage ? () => onSendMessage(invoice) : undefined}
       />
 

--- a/src/shared/api/message/index.ts
+++ b/src/shared/api/message/index.ts
@@ -54,14 +54,20 @@ const mapMessageTemplate = (
 
 const mapCreatedTemplate = (
   template: CreateMessageTemplateApiResponse,
-): MessageTemplate => ({
-  id: template.templateId,
-  type: normalizeTemplateTypeFromApi(template.type),
-  title: template.title,
-  content: template.content,
-  created_at: template.createdAt,
-  updated_at: template.updatedAt,
-});
+): MessageTemplate => {
+  const templateId = template.template_id ?? template.templateId;
+  if (templateId == null) {
+    throw new Error('Template ID is missing in the create response.');
+  }
+  return {
+    id: Number(templateId),
+    type: normalizeTemplateTypeFromApi(template.type),
+    title: template.title,
+    content: template.content,
+    created_at: template.createdAt,
+    updated_at: template.updatedAt,
+  };
+};
 
 // ====================
 // GET : 메시지 템플릿 목록 불러오기

--- a/src/shared/api/message/message.types.ts
+++ b/src/shared/api/message/message.types.ts
@@ -20,7 +20,8 @@ export interface CreateMessageTemplatePayload {
 }
 
 export interface CreateMessageTemplateApiResponse {
-  templateId: number;
+  template_id?: number;
+  templateId?: number;
   type: string;
   title: string;
   content: string;

--- a/src/shared/form/Select.tsx
+++ b/src/shared/form/Select.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import { createPortal } from 'react-dom';
 
 interface SelectOption {
@@ -11,23 +19,60 @@ interface SelectProps {
   value: string;
   onChange?: (value: string) => void;
   disabled?: boolean;
+  placeholder?: string;
+  renderValue?: (label: string, option: SelectOption | null) => ReactNode;
+  renderOption?: (
+    option: SelectOption,
+    state: { isSelected: boolean; isActive: boolean },
+  ) => ReactNode;
 }
 
-function Select({ options, value, onChange, disabled = false }: SelectProps) {
+function Select({
+  options,
+  value,
+  onChange,
+  disabled = false,
+  placeholder = '선택',
+  renderValue,
+  renderOption,
+}: SelectProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
+  const listRef = useRef<HTMLUListElement | null>(null);
+  const suppressToggleRef = useRef(false);
+  const listId = useId();
   const [menuStyle, setMenuStyle] = useState<{
     top: number;
     left: number;
     width: number;
   } | null>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const menuOptions = useMemo(
+    () => [{ label: placeholder, value: '' }, ...options],
+    [options, placeholder],
+  );
 
   const selectedLabel = useMemo(
-    () => options.find((opt) => opt.value === value)?.label ?? '선택',
-    [options, value],
+    () =>
+      menuOptions.find((opt) => opt.value === value)?.label ?? placeholder,
+    [menuOptions, placeholder, value],
   );
+  const selectedOption = useMemo(
+    () => menuOptions.find((opt) => opt.value === value) ?? null,
+    [menuOptions, value],
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const selectedIndex = Math.max(
+      0,
+      menuOptions.findIndex((opt) => opt.value === value),
+    );
+    setActiveIndex(selectedIndex === -1 ? 0 : selectedIndex);
+  }, [isOpen, menuOptions, value]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -50,14 +95,56 @@ function Select({ options, value, onChange, disabled = false }: SelectProps) {
       setIsOpen(false);
     };
 
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!isOpen) return;
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setActiveIndex((prev) => Math.min(prev + 1, menuOptions.length - 1));
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setActiveIndex((prev) => Math.max(prev - 1, 0));
+      }
+      if (event.key === 'Home') {
+        event.preventDefault();
+        setActiveIndex(0);
+      }
+      if (event.key === 'End') {
+        event.preventDefault();
+        setActiveIndex(menuOptions.length - 1);
+      }
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        const target = menuOptions[activeIndex];
+        if (target) {
+          handleSelect(target.value);
+        }
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setIsOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+
     window.addEventListener('pointerdown', handlePointerDown);
     window.addEventListener('scroll', handleScroll, true);
     window.addEventListener('resize', handleScroll);
+    window.addEventListener('keydown', handleKeyDown, true);
     return () => {
       window.removeEventListener('pointerdown', handlePointerDown);
       window.removeEventListener('scroll', handleScroll, true);
       window.removeEventListener('resize', handleScroll);
+      window.removeEventListener('keydown', handleKeyDown, true);
     };
+  }, [isOpen, activeIndex, menuOptions]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const raf = requestAnimationFrame(() => {
+      listRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(raf);
   }, [isOpen]);
 
   useLayoutEffect(() => {
@@ -90,24 +177,67 @@ function Select({ options, value, onChange, disabled = false }: SelectProps) {
     return () => cancelAnimationFrame(raf);
   }, [isOpen]);
 
+  const handleSelect = (nextValue: string) => {
+    onChange?.(nextValue);
+    setIsOpen(false);
+    suppressToggleRef.current = true;
+    triggerRef.current?.focus();
+  };
+
   return (
     <div className="relative" ref={dropdownRef}>
       <button
         type="button"
         ref={triggerRef}
         disabled={disabled}
-        onClick={() => !disabled && setIsOpen((prev) => !prev)}
+        onClick={() => {
+          if (disabled) return;
+          if (suppressToggleRef.current) {
+            suppressToggleRef.current = false;
+            return;
+          }
+          setIsOpen((prev) => !prev);
+        }}
+        onKeyDown={(event) => {
+          if (disabled) return;
+          if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+            event.preventDefault();
+            if (!isOpen) {
+              setIsOpen(true);
+            }
+            return;
+          }
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            if (suppressToggleRef.current) {
+              suppressToggleRef.current = false;
+              return;
+            }
+            if (!isOpen) {
+              setIsOpen(true);
+            }
+          }
+        }}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-controls={listId}
         className={`relative w-full rounded-sm border px-2 py-1.5 pr-9 text-left text-sm transition-colors ${
           disabled
             ? 'bg-gray-100 text-gray-400 cursor-not-allowed border-gray-400'
             : 'bg-white text-primary border-primary hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
         }`}
       >
-        <span
-          className={`block truncate ${disabled ? 'text-gray-400' : 'text-primary'}`}
-        >
-          {selectedLabel}
-        </span>
+        {renderValue ? (
+          renderValue(selectedLabel, selectedOption)
+        ) : (
+          <span
+            className={`block truncate ${
+              disabled ? 'text-gray-400' : 'text-primary'
+            }`}
+          >
+            {selectedLabel}
+          </span>
+        )}
         <span
           className={`pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 ${
             disabled ? 'text-gray-400' : 'text-primary'
@@ -155,36 +285,71 @@ function Select({ options, value, onChange, disabled = false }: SelectProps) {
                 pointerEvents: menuStyle ? 'auto' : 'none',
               }}
             >
-              <button
-                type="button"
-                onClick={() => {
-                  onChange?.('');
-                  setIsOpen(false);
+              <ul
+                id={listId}
+                ref={listRef}
+                role="listbox"
+                tabIndex={0}
+                aria-activedescendant={`${listId}-option-${activeIndex}`}
+                className="flex flex-col gap-1 p-1 text-sm focus:outline-none"
+                onKeyDown={(event) => {
+                  if (event.key === 'ArrowDown') {
+                    event.preventDefault();
+                    setActiveIndex((prev) =>
+                      Math.min(prev + 1, menuOptions.length - 1),
+                    );
+                  }
+                  if (event.key === 'ArrowUp') {
+                    event.preventDefault();
+                    setActiveIndex((prev) => Math.max(prev - 1, 0));
+                  }
+                  if (event.key === 'Home') {
+                    event.preventDefault();
+                    setActiveIndex(0);
+                  }
+                  if (event.key === 'End') {
+                    event.preventDefault();
+                    setActiveIndex(menuOptions.length - 1);
+                  }
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    const target = menuOptions[activeIndex];
+                    if (target) {
+                      handleSelect(target.value);
+                    }
+                  }
+                  if (event.key === 'Escape') {
+                    event.preventDefault();
+                    setIsOpen(false);
+                    triggerRef.current?.focus();
+                  }
                 }}
-                className={`w-full px-3 py-2 text-left text-sm transition-colors ${
-                  value === '' ? 'bg-gray-50 text-gray-900' : 'text-gray-600'
-                } hover:bg-gray-50`}
               >
-                선택
-              </button>
-              {options.map((opt) => {
-                const isActive = opt.value === value;
-                return (
-                  <button
-                    key={opt.value}
-                    type="button"
-                    onClick={() => {
-                      onChange?.(opt.value);
-                      setIsOpen(false);
-                    }}
-                    className={`w-full px-3 py-2 text-left text-sm transition-colors ${
-                      isActive ? 'bg-primary/10 text-primary' : 'text-gray-700'
-                    } hover:bg-gray-50`}
-                  >
-                    {opt.label}
-                  </button>
-                );
-              })}
+                {menuOptions.map((opt, index) => {
+                  const isSelected = opt.value === value;
+                  const isActive = index === activeIndex;
+                  return (
+                    <li key={`${opt.value || 'empty'}-${index}`}>
+                      <button
+                        id={`${listId}-option-${index}`}
+                        type="button"
+                        role="option"
+                        aria-selected={isSelected}
+                        onClick={() => handleSelect(opt.value)}
+                        className={`w-full px-3 py-2 text-left text-sm transition-colors ${
+                          isSelected
+                            ? 'bg-primary/10 text-primary'
+                            : 'text-gray-700'
+                        } ${isActive ? 'bg-gray-50' : ''} hover:bg-gray-50`}
+                      >
+                        {renderOption
+                          ? renderOption(opt, { isSelected, isActive })
+                          : opt.label}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
             </div>,
             document.body,
           )

--- a/src/shared/modal/ConfirmModal.tsx
+++ b/src/shared/modal/ConfirmModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import ModalWrapper from './ModalWrapper';
 
 interface ConfirmModalProps {
@@ -23,20 +23,49 @@ function ConfirmModal({
   onCancel,
 }: ConfirmModalProps) {
   const [canBackdropClose, setCanBackdropClose] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const confirmButtonRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
-    if (isOpen) {
-      setCanBackdropClose(false);
-      const timer = setTimeout(() => {
-        setCanBackdropClose(true);
-      }, 100);
+    if (!isOpen) return;
+    setCanBackdropClose(false);
+    const timer = setTimeout(() => {
+      setCanBackdropClose(true);
+    }, 100);
 
-      return () => clearTimeout(timer);
-    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        handleConfirm();
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onCancel();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown, true);
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener('keydown', handleKeyDown, true);
+    };
+  }, [isOpen, onCancel, onConfirm]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const raf = requestAnimationFrame(() => {
+      confirmButtonRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(raf);
   }, [isOpen]);
 
   const handleBackdropClose = () => {
     if (!canBackdropClose) return;
+    onCancel();
+  };
+
+  const handleConfirm = () => {
+    onConfirm();
     onCancel();
   };
 
@@ -47,7 +76,7 @@ function ConfirmModal({
       onClose={handleBackdropClose}
       className="w-90! min-h-0! h-auto!"
     >
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4" tabIndex={-1} ref={wrapperRef}>
         <div className="flex flex-col gap-1">
           <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
           {description && (
@@ -66,7 +95,8 @@ function ConfirmModal({
           </button>
           <button
             type="button"
-            onClick={onConfirm}
+            onClick={handleConfirm}
+            ref={confirmButtonRef}
             className={`h-10 rounded-md px-4 text-sm font-semibold text-white ${
               isDanger
                 ? 'bg-rose-600 hover:bg-rose-700'

--- a/src/store/message/messageTemplateStore.ts
+++ b/src/store/message/messageTemplateStore.ts
@@ -220,6 +220,12 @@ export const useMessageTemplateStore = create<MessageTemplateStore>(
     },
 
     deleteTemplate: async (id) => {
+      if (!Number.isFinite(id)) {
+        useToastStore
+          .getState()
+          .addToast('error', '삭제할 템플릿 ID가 없습니다.');
+        return;
+      }
       const { templates, selectedTemplateId, totalCount } = get();
 
       try {


### PR DESCRIPTION
**요약**
- 청구서 편집 화면의 중복 액션 노출을 정리했습니다.
- 문자 템플릿 선택/전환 경험과 API 안정성을 함께 개선했습니다.

**주요 변경사항**
- 청구서 수정 모드에서 불필요한 헤더 액션을 제거해 버튼 노출을 정리
- 템플릿 선택 UI를 공통 셀렉트 컴포넌트로 전환하고 키보드 탐색/커스텀 렌더링 지원
- 템플릿 전환 확인 모달의 문구/동작을 변경 사항 폐기 흐름에 맞게 정리하고 포커스/키보드 처리 추가
- 템플릿 생성 응답에서 ID 키 변형을 안전하게 처리하고 누락 시 오류 처리 강화
- 잘못된 템플릿 삭제 요청을 사전에 차단

**테스트/확인 포인트**
- 청구서 편집 진입 시 취소/저장 버튼이 중복 노출되지 않는지
- 메시지 작성 화면에서 템플릿 선택/불러오기 동작 및 키보드 탐색이 정상인지
- 템플릿 전환 시 변경 사항 폐기 확인 모달이 올바르게 동작하는지
- 템플릿 생성/삭제 API 응답에서 ID 처리 문제가 없는지

테스트 실행하지 않음