### PR TITLE
주요 사용자 흐름 알림을 toast로 통일 (학생/인증/예약/청구서)

### DIFF
--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -4,10 +4,12 @@ import { useNavigate } from 'react-router-dom';
 import InputField from './components/InputField';
 import LoginButton from './components/LoginButton';
 import LogoName from './components/LogoName';
+import { useToastStore } from '@/store/feedback/toastStore';
 
 function LoginPage() {
   const [password, setPassword] = useState('');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { addToast } = useToastStore();
 
   const navigate = useNavigate();
   const adminPassword = import.meta.env.VITE_ADMIN_PASSWORD;
@@ -25,7 +27,7 @@ function LoginPage() {
     }
 
     setErrorMessage(null);
-    alert('로그인되었습니다.');
+    addToast('success', '로그인되었습니다.');
     navigate('/home');
   };
 

--- a/src/pages/message/send/SendMessageForm/hooks/useReservationFlow.ts
+++ b/src/pages/message/send/SendMessageForm/hooks/useReservationFlow.ts
@@ -1,6 +1,7 @@
 import { useDateModalStore } from '@/store/date/dateModalStore';
 import { useTimeModalStore } from '@/store/date/timeModalStore';
 import type { MessageRecipient } from '@/store/message/messageSendStore';
+import { useToastStore } from '@/store/feedback/toastStore';
 
 interface ReservationPayloadInput {
   content: string;
@@ -23,6 +24,7 @@ export const useReservationFlow = ({
     selectedHour,
     selectedMin,
   } = useTimeModalStore();
+  const { addToast } = useToastStore();
 
   const pad2 = (value: string | number) => String(value).padStart(2, '0');
   const formatDate = (dateValue: string) => {
@@ -53,13 +55,13 @@ export const useReservationFlow = ({
 
   const handleTimeSave = () => {
     if (!selectedDate || selectedHour === null || selectedMin === null) {
-      alert('날짜와 시간을 모두 선택해주세요.');
+      addToast('warning', '날짜와 시간을 모두 선택해주세요.');
       return;
     }
 
     const startDate = new Date(selectedDate);
     if (Number.isNaN(startDate.getTime())) {
-      alert('선택한 날짜 형식이 올바르지 않습니다.');
+      addToast('error', '선택한 날짜 형식이 올바르지 않습니다.');
       return;
     }
 

--- a/src/pages/student/components/InvoiceListModal/components/invoiceCard/hooks/useInvoiceCard.ts
+++ b/src/pages/student/components/InvoiceListModal/components/invoiceCard/hooks/useInvoiceCard.ts
@@ -84,7 +84,7 @@ export default function useInvoiceCard(
 
   const handleSave = async () => {
     if (validationError) {
-      alert(validationError);
+      addToast('warning', validationError);
       return;
     }
 
@@ -114,7 +114,7 @@ export default function useInvoiceCard(
       } else {
         console.error(e);
       }
-      alert('청구 정보 수정에 실패했습니다.');
+      addToast('error', '청구 정보 수정에 실패했습니다.');
     } finally {
       setLoading(false);
     }

--- a/src/pages/student/components/InvoiceListModal/index.tsx
+++ b/src/pages/student/components/InvoiceListModal/index.tsx
@@ -12,6 +12,7 @@ import type {
   StudentInvoiceItem,
 } from '@/types/invoice';
 import { useMessageSendModalStore } from '@/store/message/messageSendModalStore';
+import { useToastStore } from '@/store/feedback/toastStore';
 import type { InvoiceData } from './components/invoiceCard/types';
 
 // 학생 청구서 목록 모달 컴포넌트
@@ -20,6 +21,7 @@ export default function InvoiceListModal() {
   const [loading, setLoading] = useState(false); // 로딩 상태 관리
   const [invociesList, setInvociesList] = useState<StudentInvoiceItem[]>([]); // 청구서 목록 상태 관리
   const { open: openMessageSendModal } = useMessageSendModalStore();
+  const { addToast } = useToastStore();
 
   // 학생의 청구서 목록을 API에서 불러오는 함수
   const load = async () => {
@@ -31,7 +33,7 @@ export default function InvoiceListModal() {
       setInvociesList(res.items);
     } catch (e) {
       console.error(e);
-      alert('청구서 정보를 불러오는데 실패했습니다.');
+      addToast('error', '청구서 정보를 불러오는데 실패했습니다.');
       close();
     } finally {
       setLoading(false);

--- a/src/pages/student/components/StudentDetailModal/components/StudentCreateForm.tsx
+++ b/src/pages/student/components/StudentDetailModal/components/StudentCreateForm.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import NormalButton from '@/shared/button/NormalButton';
 import { createStudent } from '@/shared/api/students';
 import ConfirmModal from '@/shared/modal/ConfirmModal';
+import { useToastStore } from '@/store/feedback/toastStore';
 import { useStudentModalStore } from '@/store/student/studentModalStore';
 import StudentFormFields from './shared/StudentFormFields';
 import {
@@ -21,6 +22,7 @@ function StudentCreateForm({
   onSuccess,
 }: StudentCreateFormProps) {
   const { close } = useStudentModalStore(); // 모달 닫기 함수
+  const { addToast } = useToastStore();
   const [form, setForm] = useState<StudentFormState>(INITIAL_FORM); // 폼 상태 관리
   const [isResetConfirmOpen, setIsResetConfirmOpen] = useState(false);
   const isDirty = JSON.stringify(form) !== JSON.stringify(INITIAL_FORM); // 폼이 초기 상태에서 변경되었는지 여부
@@ -47,7 +49,7 @@ function StudentCreateForm({
   // 폼 제출 핸들러
   const handleSubmit = async () => {
     if (!isValidStudentForm(form)) {
-      alert('필수 항목을 모두 입력해주세요.');
+      addToast('error', '필수 항목을 모두 입력해주세요.');
       return;
     }
 
@@ -63,10 +65,11 @@ function StudentCreateForm({
       setForm(INITIAL_FORM);
       onDirtyChange(false);
       onSuccess();
+      addToast('success', '학생이 추가되었습니다.');
       close();
     } catch (error) {
       console.error('학생 등록 실패', error);
-      alert('학생 등록에 실패했습니다.');
+      addToast('error', '학생 등록에 실패했습니다.');
     }
   };
 

--- a/src/pages/student/components/StudentDetailModal/components/StudentDetailView.tsx
+++ b/src/pages/student/components/StudentDetailModal/components/StudentDetailView.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import NormalButton from '@/shared/button/NormalButton';
 import ConfirmModal from '@/shared/modal/ConfirmModal';
 import { updateStudent } from '@/shared/api/students';
+import { useToastStore } from '@/store/feedback/toastStore';
 import { useStudentModalStore } from '@/store/student/studentModalStore';
 import { useInvoiceModalStore } from '@/store/invoice/invoiceModalStore';
 import StudentFormFields from './shared/StudentFormFields';
@@ -30,6 +31,7 @@ function StudentDetailView({
     useState<StudentFormState>(mappedStudent); // 원본 폼 상태 저장 (수정 취소 시 사용)
   const [form, setForm] = useState<StudentFormState>(mappedStudent); // 현재 폼 상태
   const [isCancelConfirmOpen, setIsCancelConfirmOpen] = useState(false);
+  const { addToast } = useToastStore();
   const { mode, openUpdate, openDetail } = useStudentModalStore(); // 모달 상태에서 현재 모드와 학생 상세/수정 오픈 함수 가져오기
   const isEditMode = mode === 'UPDATE'; //
 
@@ -73,7 +75,7 @@ function StudentDetailView({
   const handleSave = async () => {
     // 1. 폼 유효성 검사 - 필수 항목이 모두 입력되었는지 확인
     if (!isValidStudentForm(form)) {
-      alert('필수 항목을 모두 입력해주세요.');
+      addToast('error', '필수 항목을 모두 입력해주세요.');
       return;
     }
 
@@ -92,9 +94,10 @@ function StudentDetailView({
       onDirtyChange(false);
       onSuccess();
       openDetail(updatedStudent);
+      addToast('success', '학생 정보가 수정되었습니다.');
     } catch (error) {
       console.error('학생 수정 실패', error);
-      alert('학생 수정에 실패했습니다.');
+      addToast('error', '학생 수정에 실패했습니다.');
     }
   };
 
@@ -129,11 +132,6 @@ function StudentDetailView({
           {isEditMode && (
             <>
               <NormalButton
-                text="저장"
-                onClick={handleSave}
-                disabled={!isDirty}
-              />
-              <NormalButton
                 text="취소"
                 onClick={() => {
                   if (isDirty) {
@@ -142,6 +140,11 @@ function StudentDetailView({
                   }
                   handleCancelEdit();
                 }}
+              />
+              <NormalButton
+                text="저장"
+                onClick={handleSave}
+                disabled={!isDirty}
               />
             </>
           )}

--- a/src/shared/Layout/PrivateSidebar.tsx
+++ b/src/shared/Layout/PrivateSidebar.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { MenuList } from './menuList/MenuList';
 import { IoIosLogOut } from 'react-icons/io';
+import { useToastStore } from '@/store/feedback/toastStore';
 
 function PrivateSidebar() {
   return (
@@ -33,11 +34,12 @@ const LogoName = () => {
 
 const LogoutButton = ({ compact = false }: { compact?: boolean }) => {
   const navigate = useNavigate();
+  const { addToast } = useToastStore();
 
   const handleLogout = () => {
     // 👉 추후 실제 로그아웃 로직 추가 가능
     // ex) auth.signOut(), 토큰 삭제 등
-    alert('로그아웃 되었습니다.');
+    addToast('info', '로그아웃 되었습니다.');
     navigate('/');
   };
 


### PR DESCRIPTION
**요약**
- 학생 추가/수정 및 주요 사용자 흐름의 알림을 toast로 통일했습니다.

**주요 변경사항**
- 학생 추가/수정 모달에서 성공·실패 및 유효성 안내를 toast로 표시하도록 변경했습니다.
- 로그인/로그아웃 안내를 toast로 전환했습니다.
- 예약 시간 선택 검증 실패 시 toast로 경고/오류를 표시하도록 수정했습니다.
- 청구서 로딩 실패 및 청구서 수정 실패/검증 안내를 toast로 통일했습니다.

**테스트/확인 포인트**
- 학생 추가/수정 성공/실패 시 toast 노출 확인
- 로그인/로그아웃 시 toast 노출 확인
- 예약 시간 미선택/형식 오류 시 toast 노출 확인
- 청구서 로딩 실패 및 수정 실패/검증 시 toast 노출 확인
- 테스트 실행하지 않음